### PR TITLE
feat(neo-tree): add open-and-diff key

### DIFF
--- a/docs/productivity.md
+++ b/docs/productivity.md
@@ -45,6 +45,7 @@
   - `<leader>be`：Buffers 视图。
 - 说明：
   - 在 git_status 视图中可直接回车跳转到改动文件。
+  - 在 git_status 视图中按 `D` 打开并直接进入 diff（会覆盖当前 tab 内已有 diff 视图）。
   - 在 filesystem 视图中可查看 Git 标记并进行常规文件操作。
 
 ## Git Diff 视图：diffview.nvim

--- a/lua/plugins/common.lua
+++ b/lua/plugins/common.lua
@@ -64,6 +64,33 @@ return {
             hide_gitignored = true,
           },
         },
+        git_status = {
+          window = {
+            mappings = {
+              ["D"] = "open_and_diff",
+            },
+          },
+          commands = {
+            open_and_diff = function(state)
+              local commands = require("neo-tree.sources.common.commands")
+              commands.open(state)
+              vim.schedule(function()
+                local tab = vim.api.nvim_get_current_tabpage()
+                local cur = vim.api.nvim_get_current_win()
+                for _, win in ipairs(vim.api.nvim_tabpage_list_wins(tab)) do
+                  if vim.wo[win].diff then
+                    if win == cur then
+                      vim.wo[win].diff = false
+                    else
+                      vim.api.nvim_win_close(win, true)
+                    end
+                  end
+                end
+                require("gitsigns").diffthis("~")
+              end)
+            end,
+          },
+        },
         default_component_configs = {
           git_status = {
             symbols = {


### PR DESCRIPTION
Why:
- Speed up reviewing changes from the git_status view.

What:
- Add a git_status mapping to open a file and enter diff view.
- Close existing diff windows before opening a new diff.
- Document the new key in productivity docs.

Impact:
- New keybinding in Neo-tree git_status; diff views replace prior diff splits.

Tests:
- not run (config/doc change)

Refs:
- N/A