### PR TITLE
feat(tmux): add language coach and shared status

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -70,9 +70,11 @@ set -g status-left-length 30
 
 # 两行状态栏：
 # - 第 1 行：正常状态栏（window 列表 + status-left/status-right）
-# - 第 2 行：左侧 Codex 最近一次完成；右侧 Git 状态（右下角）
+# - 第 2 行：左侧共享消息槽（Codex/Language 常驻，后触发覆盖前触发）；右侧 Git 状态
 set -g status 2
-set -g status-format[1] '#[align=left]#{?@codex_last_win,#[fg=cyan]Codex#[default]: #{@codex_last_win}#{?@codex_last_summary, | #{=/60/...:@codex_last_summary},},#[fg=cyan]Codex#[default]: -}#[align=right]#(~/.config/nvim/tmux/bin/tmux-git-status "#{pane_current_path}")'
+# 输入提示与消息显示在第 2 行（索引从 0 开始）
+set -g message-line 1
+set -g status-format[1] '#[align=left]#(~/.config/nvim/tmux/bin/tmux-git-status "#{pane_current_path}")#[align=right]#{?@shared_status_msg,#{=/110/...:@shared_status_msg},}'
 # 第 1 行左侧只显示 session 名称（导航信息，避免抢占注意力）
 set -g status-left '#[fg=colour245][#{session_name} #{session_id}]'
 
@@ -94,7 +96,7 @@ set -g status-right "#(~/.tmux/plugins/tmux-continuum/scripts/continuum_save.sh)
 # - @codex_last_win  / @codex_last_pane：最后一次完成的位置
 # - ~/.tmux-codex-history：历史记录（用于菜单选择）
 set -g @codex_history_file "$HOME/.tmux-codex-history"
-# 不使用弹窗/消息条（用第 2 行状态栏显示即可）
+# Codex 和 Language 共用第二行常驻消息槽（不再额外弹消息条）
 set -g @codex_notify_mode "off" # popup | message | off
 
 # <prefix> + C：弹出最近完成列表（最新在上），选择后跳回对应 pane
@@ -105,3 +107,9 @@ bind-key J run-shell -b 'bash "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/tmux/bin/c
 
 # Popup 终端：在当前 pane 路径打开一个临时 shell
 bind-key G display-popup -E -w 90% -h 85% -T "Terminal" -d "#{pane_current_path}" "bash"
+
+# Language Coach：输入中英文（后台执行），结果复制到剪贴板并提示
+bind-key g command-prompt -p "Language input" 'run-shell -b "TMUX_LANG_AUTOPASTE=0 bash \"$HOME/.config/nvim/tmux/bin/tmux-language-rewrite\" \"%%\""'
+
+# Language Coach History：只读历史查看
+bind-key H display-popup -E -w 90% -h 65% -T "Language History" 'bash "$HOME/.config/nvim/tmux/bin/tmux-language-history"'

--- a/tmux/.tmux.conf.wsl
+++ b/tmux/.tmux.conf.wsl
@@ -77,9 +77,11 @@ set -g status-left-length 30
 
 # 两行状态栏：
 # - 第 1 行：正常状态栏（window 列表 + status-left/status-right）
-# - 第 2 行：左侧 Codex 最近一次完成；右侧 Git 状态（右下角）
+# - 第 2 行：左侧共享消息槽（Codex/Language 常驻，后触发覆盖前触发）；右侧 Git 状态
 set -g status 2
-set -g status-format[1] '#[align=left]#{?@codex_last_win,#[fg=cyan]Codex#[default]: #{@codex_last_win}#{?@codex_last_summary, | #{=/60/...:@codex_last_summary},},#[fg=cyan]Codex#[default]: -}#[align=right]#(~/.config/nvim/tmux/bin/tmux-git-status "#{pane_current_path}")'
+# 输入提示与消息显示在第 2 行（索引从 0 开始）
+set -g message-line 1
+set -g status-format[1] '#[align=left]#(~/.config/nvim/tmux/bin/tmux-git-status "#{pane_current_path}")#[align=right]#{?@shared_status_msg,#{=/110/...:@shared_status_msg},}'
 
 # in .tmux.conf
 set -g status-right "#(~/.tmux/plugins/tmux-continuum/scripts/continuum_save.sh) #(awk -v RS=\"\" '/^cpu / {u=$2+$4; t=$2+$4+$5; printf \"CPU: %.1f%%\", u*100/t}' /proc/stat) | #(free -m | awk '/Mem/ {printf \"RAM: %.1f%%\", $3*100/$2 }') | %a %h-%d %H:%M "
@@ -89,7 +91,7 @@ set -g status-right "#(~/.tmux/plugins/tmux-continuum/scripts/continuum_save.sh)
 # - @codex_last_win  / @codex_last_pane：最后一次完成的位置
 # - ~/.tmux-codex-history：历史记录（用于菜单选择）
 set -g @codex_history_file "$HOME/.tmux-codex-history"
-# 不使用弹窗/消息条（用第 2 行状态栏显示即可）
+# Codex 和 Language 共用第二行常驻消息槽（不再额外弹消息条）
 set -g @codex_notify_mode "off" # popup | message | off
 
 # <prefix> + C：弹出最近完成列表（最新在上），选择后跳回对应 pane
@@ -113,6 +115,12 @@ bind-key W command-prompt -p "window name" "rename-window '%%'"
 
 # Popup 终端：在当前 pane 路径打开一个临时 shell
 bind-key G display-popup -E -w 90% -h 85% -T "Terminal" -d "#{pane_current_path}" "bash"
+
+# Language Coach：输入中英文（后台执行），结果复制到剪贴板并提示
+bind-key g command-prompt -p "Language input" 'run-shell -b "TMUX_LANG_AUTOPASTE=0 bash \"$HOME/.config/nvim/tmux/bin/tmux-language-rewrite\" \"%%\""'
+
+# Language Coach History：只读历史查看
+bind-key H display-popup -E -w 90% -h 65% -T "Language History" 'bash "$HOME/.config/nvim/tmux/bin/tmux-language-history"'
 
 ##### Yank：复制后仍停留在 copy-mode（Windows UTF-8）#####
 # 注意：这段必须放在 TPM 之后，确保覆盖 tmux-yank 的默认绑定

--- a/tmux/README.md
+++ b/tmux/README.md
@@ -58,17 +58,25 @@ Windows Terminal + WSL 的中文复制问题与配置要点见：
 当前模板使用两行状态栏：
 - 第 1 行左侧：`session_name + session_id`
 - 第 1 行右侧：`CPU | RAM | time`
-- 第 2 行左侧：最近一次 Codex 完成信息
-- 第 2 行右侧（右下角）：当前 pane 路径的 Git 状态（`git:<branch>`，未提交为 `*`，有远端差距时显示 `+ahead/-behind`）
+- 第 2 行左侧：当前 pane 路径的 Git 状态（`git:<branch>`，未提交为 `*`，有远端差距时显示 `+ahead/-behind`）
+- 第 2 行右侧：共享常驻消息槽（Codex/Language 共用，后触发覆盖前触发）
 
 常用操作：
 - `<prefix> + T`：设置当前 pane 标签（显示在 pane 边框）
 - `<prefix> + W`：重命名当前 window
 - `<prefix> + G`：在当前 pane 路径打开 popup shell（用于临时执行 `git status/log/push` 等）
+- `<prefix> + g`：在底部输入一句中文/英文，后台生成地道英文并复制到剪贴板（可用时），完成后更新第 2 行左侧常驻消息槽
+- `<prefix> + H`：打开 Language Coach 只读历史（最近记录）
 
 排查：
 - 如果状态栏频繁闪烁，通常是 `status-interval` 太短或 status-right 命令太重：
   - 可以把 `status-interval` 调大（例如 5/10 秒）
+
+Language Coach 依赖（可选）：
+- 推荐安装 `translate-shell`（命令 `trans`），否则脚本会退化为原文输出。
+- 脚本优先使用 `@clipboard`，其次尝试 `pbcopy/wl-copy/xclip/xsel/win32yank.exe/clip.exe`。
+- 历史文件默认保存在 `~/.tmux-language-history`（本地文件，不入库）。
+- 输入提示固定在状态栏第 2 行（`message-line=1`）。
 
 ## Codex（可选）：turn 完成提示 + 快速跳回
 如果你在 tmux 里运行 Codex CLI，经常会切到别的 pane 做其他事，那么“回到 Codex 输出的 pane”
@@ -78,8 +86,9 @@ Codex CLI 支持 `notify` hook：每次 turn 结束会执行一次你配置的�
 集成脚本模板：`tmux/bin/codex-tmux-notify`。
 
 效果（推荐：不打断输入）：
-- 状态栏第 2 行常驻显示最近一次完成信息：`Codex: <session:window> | <summary?>`
+- Codex 完成会更新第 2 行左侧常驻消息：`Codex: <session:window> | <summary?>`
   - `<summary?>` 会尽量从 notify 的 JSON 里取最后一条回复的首行（依赖 `python3`，没有也不影响跳转）
+- Language 翻译完成也写入同一消息槽，后触发者覆盖前一个结果
 - pane 顶部边框会显示三段：`编号 | 你的标签 | Codex 摘要`
 - Codex 完成后会把摘要写入当前 pane 的 `@codex_pane_summary`（不再覆盖 pane title）
 - 历史条目会记录会话线程 ID（优先使用 `CODEX_THREAD_ID`，否则尝试从 notify JSON 提取）
@@ -131,7 +140,7 @@ notify 每次触发都会：
 
 可选参数（写在 `tmux/.tmux.conf(.wsl)` 里）：
 - `set -g @codex_history_limit 12`：列表最多显示多少条（默认 12）
-- `set -g @codex_notify_mode off`：不弹窗/不消息条（推荐，配合第 2 行状态栏即可）
+- `set -g @codex_notify_mode off`：不额外弹窗/消息条（推荐，常驻槽模式）
 - `set -g @codex_notify_mode message`：额外用 tmux 消息条提示（非模态）
 - `set -g @codex_notify_mode popup`：额外用 popup 弹窗提示（模态：会捕获按键并暂停 pane 刷新）
 - `set -g @codex_popup_corner br`：popup 位置：`tr/br/tl/bl`（右上/右下/左上/左下）

--- a/tmux/bin/codex-tmux-notify
+++ b/tmux/bin/codex-tmux-notify
@@ -88,6 +88,16 @@ tmux set -gq @codex_last_pane "$pane"
 tmux set -gq @codex_last_path "$path"
 [ -n "$summary" ] && tmux set -gq @codex_last_summary "$summary"
 [ -n "$thread_id" ] && tmux set -gq @codex_last_thread_id "$thread_id"
+
+# Update shared second-line status slot (persistent until overwritten).
+shared_msg="Codex: $win"
+if [ -n "$summary" ]; then
+  shared_msg="$shared_msg | $summary"
+fi
+# Prevent tmux format interpolation for user content.
+shared_msg="${shared_msg//#/##}"
+tmux set -gq @shared_status_msg "$shared_msg"
+
 tmux refresh-client -S 2>/dev/null || true
 if [ -n "$summary" ]; then
   tmux set -p -t "$pane" @codex_pane_summary "$summary" 2>/dev/null || true

--- a/tmux/bin/tmux-language-history
+++ b/tmux/bin/tmux-language-history
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -u
+
+history_file="${TMUX_LANG_HISTORY_FILE:-$HOME/.tmux-language-history}"
+limit="${1:-30}"
+
+if ! printf '%s' "$limit" | grep -Eq '^[0-9]+$'; then
+  limit=30
+fi
+
+printf "Language history (latest %s)\n\n" "$limit"
+
+if [ ! -s "$history_file" ]; then
+  printf "No history yet.\n\n"
+  printf "Press Enter to close..."
+  IFS= read -r _
+  exit 0
+fi
+
+tail -n "$limit" "$history_file" | nl -ba -w2 -s'. ' | awk -F '\t' '
+{
+  idx=$1
+  ts=$2
+  in_txt=$3
+  out_txt=$4
+  printf "%s [%s]\n", idx, ts
+  printf "  IN : %s\n", in_txt
+  printf "  OUT: %s\n\n", out_txt
+}
+'
+
+printf "Press Enter to close..."
+IFS= read -r _

--- a/tmux/bin/tmux-language-rewrite
+++ b/tmux/bin/tmux-language-rewrite
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -u
+
+input="${1-}"
+auto_paste="${TMUX_LANG_AUTOPASTE-0}"
+target_pane="${TMUX_LANG_TARGET-}"
+history_file="${TMUX_LANG_HISTORY_FILE:-$HOME/.tmux-language-history}"
+if [ -z "$input" ]; then
+  printf "Input (zh/en): "
+  IFS= read -r input || exit 0
+fi
+
+input="$(printf '%s' "$input" | sed 's/[[:space:]]\+$//')"
+if [ -z "$input" ]; then
+  tmux display-message "Language: empty input"
+  exit 0
+fi
+
+rewrite_to_english() {
+  if command -v trans >/dev/null 2>&1; then
+    # Chinese input -> English translation.
+    if printf '%s' "$input" | grep -q '[一-龥]'; then
+      trans -b zh:en "$input" 2>/dev/null && return 0
+    fi
+
+    # Non-Chinese input: try EN -> ZH -> EN for a more natural paraphrase.
+    zh_text="$(trans -b :zh "$input" 2>/dev/null || true)"
+    if [ -n "$zh_text" ]; then
+      trans -b zh:en "$zh_text" 2>/dev/null && return 0
+    fi
+
+    trans -b :en "$input" 2>/dev/null && return 0
+  fi
+
+  printf '%s' "$input"
+}
+
+result="$(rewrite_to_english | tr '\r' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+[ -n "$result" ] || result="$input"
+
+record_history() {
+  ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date)"
+  in_text="$(printf '%s' "$input" | tr '\r\n\t' '   ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+  out_text="$(printf '%s' "$result" | tr '\r\n\t' '   ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+  printf '%s\t%s\t%s\n' "$ts" "$in_text" "$out_text" >> "$history_file" 2>/dev/null || true
+}
+record_history
+
+copy_ok=0
+copy_via="tmux-buffer"
+
+# Always keep one copy in tmux buffer.
+tmux set-buffer -- "$result" >/dev/null 2>&1 || true
+
+clip_cmd="$(tmux show -gv @clipboard 2>/dev/null || true)"
+if [ -n "$clip_cmd" ] && printf '%s' "$result" | sh -c "$clip_cmd" >/dev/null 2>&1; then
+  copy_ok=1
+  copy_via="@clipboard"
+fi
+
+if [ "$copy_ok" -eq 0 ] && command -v pbcopy >/dev/null 2>&1; then
+  if printf '%s' "$result" | pbcopy >/dev/null 2>&1; then
+    copy_ok=1
+    copy_via="pbcopy"
+  fi
+fi
+
+if [ "$copy_ok" -eq 0 ] && command -v wl-copy >/dev/null 2>&1; then
+  if printf '%s' "$result" | wl-copy >/dev/null 2>&1; then
+    copy_ok=1
+    copy_via="wl-copy"
+  fi
+fi
+
+if [ "$copy_ok" -eq 0 ] && command -v xclip >/dev/null 2>&1; then
+  if printf '%s' "$result" | xclip -selection clipboard >/dev/null 2>&1; then
+    copy_ok=1
+    copy_via="xclip"
+  fi
+fi
+
+if [ "$copy_ok" -eq 0 ] && command -v xsel >/dev/null 2>&1; then
+  if printf '%s' "$result" | xsel --clipboard --input >/dev/null 2>&1; then
+    copy_ok=1
+    copy_via="xsel"
+  fi
+fi
+
+if [ "$copy_ok" -eq 0 ] && command -v win32yank.exe >/dev/null 2>&1; then
+  if printf '%s' "$result" | win32yank.exe -i --crlf >/dev/null 2>&1; then
+    copy_ok=1
+    copy_via="win32yank.exe"
+  fi
+fi
+
+if [ "$copy_ok" -eq 0 ] && command -v clip.exe >/dev/null 2>&1; then
+  if printf '%s' "$result" | clip.exe >/dev/null 2>&1; then
+    copy_ok=1
+    copy_via="clip.exe"
+  fi
+fi
+
+short="$(printf '%s' "$result" | cut -c1-80)"
+[ "${#result}" -gt 80 ] && short="${short}..."
+# Prevent tmux format interpolation for user content.
+short="${short//#/##}"
+
+if [ "$copy_ok" -eq 1 ]; then
+  shared_msg="Lang: $short"
+else
+  shared_msg="Lang(buffer): $short"
+fi
+tmux set -gq @shared_status_msg "$shared_msg" >/dev/null 2>&1 || true
+
+paste_back() {
+  if [ "$auto_paste" != "1" ]; then
+    return 0
+  fi
+
+  if [ -n "$target_pane" ]; then
+    tmux paste-buffer -t "$target_pane" >/dev/null 2>&1 && return 0
+  fi
+
+  tmux paste-buffer >/dev/null 2>&1 || true
+}
+
+if [ -t 1 ]; then
+  printf "\nOutput:\n%s\n\n" "$result"
+  if [ "$auto_paste" = "1" ] && [ "$copy_ok" -eq 1 ]; then
+    printf "Copied via %s. Press Enter to paste..." "$copy_via"
+  elif [ "$auto_paste" = "1" ]; then
+    printf "Copied to tmux buffer only. Press Enter to paste..."
+  elif [ "$copy_ok" -eq 1 ]; then
+    printf "Copied via %s. Press Enter to close..." "$copy_via"
+  else
+    printf "Copied to tmux buffer only. Press Enter to close..."
+  fi
+  IFS= read -r _
+  paste_back
+else
+  paste_back
+fi


### PR DESCRIPTION
Why:
- Tmux needed a non-blocking way to keep Codex/translation feedback visible without popup interruptions.
- Without a shared persistent slot, completion messages were fragmented and translation results were harder to reuse.

What:
- Add a shared second-line status slot via `@shared_status_msg` and wire Codex notify updates into it.
- Add `tmux/bin/tmux-language-rewrite` for rewrite/copy/history recording, plus `<prefix> + g` binding in both tmux configs.
- Add `tmux/bin/tmux-language-history` and `<prefix> + H` popup binding for quick history lookup.
- Update tmux docs to describe the new status layout, keybindings, and optional dependencies.

Impact:
- Users can trigger language rewrite from tmux and immediately reuse output from clipboard or tmux buffer.
- Codex and language feedback now share one persistent UI surface; later events overwrite earlier ones predictably.
- No migration step is required; optional translation quality improves when `trans` is installed.

Tests:
- `bash -n tmux/bin/codex-tmux-notify`
- `bash -n tmux/bin/tmux-language-history`
- `bash -n tmux/bin/tmux-language-rewrite`

Refs:
- AI-SESSION: 019c3104-0d39-7fd0-b21d-612e0ad6e977