### PR TITLE
[codex] improve tmux dispatch and prompt handoff

### DIFF
--- a/tmux/README.md
+++ b/tmux/README.md
@@ -35,10 +35,10 @@
 
 - `tmux/bin/tmux-task-window-bootstrap`
   - 负责新 task 的 worktree + tmux window + `tmux-orch` 初始注册
-  - 注入的 child prompt 会明确要求使用 `$tmux-task-orchestrator-skill`
+  - 先执行裸 `codex fork`，确认子 pane 进入 Codex 后再发送 orchestrator startup prompt
 - `tmux/bin/tmux-task-lane-bootstrap`
   - 负责单个 lane pane 的创建、pane 注册、role prompt 注入
-  - 注入的 child prompt 会明确 handoff envelope 和 pane status 刷新方式
+  - 先执行裸 `codex fork`，确认子 pane 进入 Codex 后再发送 lane startup prompt
 - `tmux/bin/tmux-task-project-handoff`
   - 负责 task window 完成后的确定性 upward handoff
   - 只按 canonical `pane_id` 把 `merge-ready` / `merge-complete` / `blocked` /

--- a/tmux/README.md
+++ b/tmux/README.md
@@ -34,11 +34,12 @@
 现在额外提供两条 orchestration-specific runtime wrapper：
 
 - `tmux/bin/tmux-task-window-bootstrap`
-  - 负责新 task 的 worktree + tmux window + `tmux-orch` 初始注册
+  - 负责新 task 的 worktree + tmux window + `tmux-orch` 初始注册（可用时）
   - 先执行裸 `codex fork`，确认子 pane 进入 Codex 后再发送 orchestrator startup prompt
 - `tmux/bin/tmux-task-lane-bootstrap`
   - 负责单个 lane pane 的创建、pane 注册、role prompt 注入
   - 先执行裸 `codex fork`，确认子 pane 进入 Codex 后再发送 lane startup prompt
+  - 没有 `jq` 或 `tmux/bin/orch` 时，继续以 tmux-only degraded mode 工作，不阻塞 lane 创建
 - `tmux/bin/tmux-task-project-handoff`
   - 负责 task window 完成后的确定性 upward handoff
   - 只按 canonical `pane_id` 把 `merge-ready` / `merge-complete` / `blocked` /
@@ -74,6 +75,10 @@ tmux/bin/tmux-task-project-handoff \
 
 ## tmux-orch（Phase A 原型）
 仓库现在包含一个最小 `tmux-orch` 原型：`tmux/bin/orch`。
+
+注意：
+- `tmux/bin/orch` 本体仍依赖 `jq`
+- `tmux-task-window-bootstrap` / `tmux-task-lane-bootstrap` 在没有 `jq` 时会降级为 tmux-only 模式，不阻塞 pane 创建与 lane dispatch
 
 它的职责很窄：
 - tmux 仍负责 live routing

--- a/tmux/README.md
+++ b/tmux/README.md
@@ -10,11 +10,12 @@
 
 ## Skill Layers
 
-`tmux/skills/` 现在分成两个公开角色和两个内部 helper：
+`tmux/skills/` 现在分成三个公开角色和两个内部 helper：
 
 公开角色：
 
 - `$tmux-project-orchestrator-skill`: 项目级协调入口，管理多个 worktree / task windows、项目状态、依赖关系与推进顺序，本身不写代码
+- `$tmux-lane-dispatch-skill`: 快速起一个 lane 的轻量入口，只做 preflight + dispatch，不进入完整 task lifecycle
 - `$tmux-task-orchestrator-skill`: 单任务窗口的长期操盘角色，负责本地 phase、lane 分配、handoff、review、commit、merge-back 与收尾
 
 内部 helper：
@@ -31,8 +32,14 @@
 
 ### Runtime Wrappers
 
-现在额外提供两条 orchestration-specific runtime wrapper：
+现在额外提供三条 orchestration-specific runtime wrapper：
 
+- `tmux/bin/tmux-orch-preflight`
+  - 负责统一的环境/能力检查，不创建 pane、不 fork Codex、不写 tmux-orch 状态
+  - 用来判断当前是否能 `dispatch lane`，以及是否具备完整 lifecycle orchestration 能力
+- `tmux/bin/tmux-dispatch-lane`
+  - 负责公共 fast-path lane dispatch
+  - 只做 preflight 通过后的 lane 启动，不承担 review/commit/merge 生命周期决策
 - `tmux/bin/tmux-task-window-bootstrap`
   - 负责新 task 的 worktree + tmux window + `tmux-orch` 初始注册（可用时）
   - 先执行裸 `codex fork`，确认子 pane 进入 Codex 后再发送 orchestrator startup prompt
@@ -49,6 +56,11 @@
 现有 `<prefix> + f` / `<prefix> + F` 仍然保持通用裸 `codex fork <id>`，不自动注入 orchestrator 语义。
 
 最小示例：
+
+```sh
+tmux/bin/tmux-dispatch-lane \
+  --task-context "finish the current slice and report back review-ready or blocked"
+```
 
 ```sh
 tmux/bin/tmux-task-window-bootstrap \

--- a/tmux/bin/tmux-dispatch-lane
+++ b/tmux/bin/tmux-dispatch-lane
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+preflight_bin="$script_dir/tmux-orch-preflight"
+lane_bootstrap_bin="$script_dir/tmux-task-lane-bootstrap"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  tmux-dispatch-lane \
+    [--role ROLE] \
+    --task-context TEXT \
+    [--phase NAME] \
+    [--window-id WINDOW_ID] \
+    [--orchestrator-pane-id PANE_ID] \
+    [--target-pane PANE_ID] \
+    [--worktree-path PATH] \
+    [--layout h|v] \
+    [--root PATH] \
+    [--session-id ID]
+
+Roles:
+  coder | issue-gate | reviewer
+
+Notes:
+  - Public fast path for lane dispatch.
+  - Runs tmux-orch-preflight first, then delegates pane mechanics to tmux-task-lane-bootstrap.
+  - Does not run lifecycle orchestration, review, commit, or merge decisions.
+EOF
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+role="coder"
+task_context=""
+phase="phase1"
+window_id=""
+orchestrator_pane_id="${TMUX_PANE:-}"
+target_pane="${TMUX_PANE:-}"
+worktree_path=""
+layout=""
+state_root=""
+session_id="${CODEX_SESSION_ID:-${CODEX_THREAD_ID:-}}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --role)
+      role="$2"
+      shift 2
+      ;;
+    --task-context | --task)
+      task_context="$2"
+      shift 2
+      ;;
+    --phase)
+      phase="$2"
+      shift 2
+      ;;
+    --window-id)
+      window_id="$2"
+      shift 2
+      ;;
+    --orchestrator-pane-id)
+      orchestrator_pane_id="$2"
+      shift 2
+      ;;
+    --target-pane)
+      target_pane="$2"
+      shift 2
+      ;;
+    --worktree-path)
+      worktree_path="$2"
+      shift 2
+      ;;
+    --layout)
+      layout="$2"
+      shift 2
+      ;;
+    --root)
+      state_root="$2"
+      shift 2
+      ;;
+    --session-id)
+      session_id="$2"
+      shift 2
+      ;;
+    -h | --help | help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "${TMUX:-}" ] || fail "tmux-dispatch-lane must run inside tmux"
+[ -n "$task_context" ] || fail "--task-context is required"
+[ -x "$preflight_bin" ] || fail "missing executable preflight helper at $preflight_bin"
+[ -x "$lane_bootstrap_bin" ] || fail "missing executable lane bootstrap helper at $lane_bootstrap_bin"
+[ -n "$window_id" ] || window_id="$(tmux display-message -p '#{window_id}')"
+[ -n "$orchestrator_pane_id" ] || orchestrator_pane_id="$(tmux display-message -p '#{pane_id}')"
+[ -n "$target_pane" ] || target_pane="$orchestrator_pane_id"
+[ -n "$worktree_path" ] || worktree_path="$(tmux display-message -p -t "$target_pane" '#{pane_current_path}')"
+[ -n "$session_id" ] || fail "missing CODEX_SESSION_ID/CODEX_THREAD_ID; pass --session-id explicitly"
+
+preflight_args=(
+  --mode dispatch
+  --worktree-path "$worktree_path"
+  --window-id "$window_id"
+  --pane-id "$orchestrator_pane_id"
+  --session-id "$session_id"
+)
+if [ -n "$state_root" ]; then
+  preflight_args+=(--root "$state_root")
+fi
+"$preflight_bin" "${preflight_args[@]}"
+
+lane_args=(
+  --role "$role"
+  --task-context "$task_context"
+  --phase "$phase"
+  --dispatcher-skill '$tmux-lane-dispatch-skill'
+  --target-pane "$target_pane"
+  --orchestrator-pane-id "$orchestrator_pane_id"
+  --window-id "$window_id"
+  --worktree-path "$worktree_path"
+  --session-id "$session_id"
+)
+if [ -n "$layout" ]; then
+  lane_args+=(--layout "$layout")
+fi
+if [ -n "$state_root" ]; then
+  lane_args+=(--root "$state_root")
+fi
+"$lane_bootstrap_bin" "${lane_args[@]}"

--- a/tmux/bin/tmux-orch-preflight
+++ b/tmux/bin/tmux-orch-preflight
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+orch_bin="$script_dir/orch"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  tmux-orch-preflight \
+    [--mode MODE] \
+    [--repo-root PATH] \
+    [--worktree-path PATH] \
+    [--window-id WINDOW_ID] \
+    [--pane-id PANE_ID] \
+    [--root PATH] \
+    [--session-id ID]
+
+Modes:
+  dispatch | orchestrate | window-bootstrap
+
+Notes:
+  - Reports required and optional environment readiness for tmux orchestration.
+  - Does not create panes, fork Codex, or mutate tmux-orch state.
+  - Exit code is 0 when required checks for the selected mode pass, 1 otherwise.
+EOF
+}
+
+need_arg() {
+  [ $# -ge 2 ] || {
+    printf 'error: missing value for %s\n' "${1:-argument}" >&2
+    exit 2
+  }
+}
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+sanitize_name() {
+  printf '%s' "$1" | tr '/ :\t' '____' | tr -cd 'A-Za-z0-9._-'
+}
+
+first_existing_dir() {
+  local path="$1"
+  while [ ! -e "$path" ] && [ "$path" != "/" ]; do
+    path="$(dirname "$path")"
+  done
+  printf '%s\n' "$path"
+}
+
+tmux_safe_display() {
+  local format="$1"
+  if has_cmd tmux && [ -n "${TMUX:-}" ]; then
+    tmux display-message -p "$format" 2>/dev/null || true
+  else
+    true
+  fi
+}
+
+pane_exists() {
+  local pane_id="$1"
+  [ -n "$pane_id" ] || return 1
+  has_cmd tmux || return 1
+  tmux list-panes -a -F '#{pane_id}' 2>/dev/null | awk -v want="$pane_id" '$1 == want { found = 1 } END { exit(found ? 0 : 1) }'
+}
+
+window_exists() {
+  local window_id="$1"
+  [ -n "$window_id" ] || return 1
+  has_cmd tmux || return 1
+  tmux list-windows -a -F '#{window_id}' 2>/dev/null | awk -v want="$window_id" '$1 == want { found = 1 } END { exit(found ? 0 : 1) }'
+}
+
+default_state_root() {
+  local base session
+  base="${TMUX_ORCH_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/tmux-orch}"
+  session="$(tmux_safe_display '#S')"
+  session="${session:-manual}"
+  session="$(sanitize_name "$session")"
+  [ -n "$session" ] || session="manual"
+  printf '%s/%s\n' "$base" "$session"
+}
+
+mode="dispatch"
+repo_root=""
+worktree_path=""
+window_id=""
+pane_id=""
+state_root=""
+session_id="${CODEX_SESSION_ID:-${CODEX_THREAD_ID:-}}"
+session_id_source="missing"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mode)
+      need_arg "$@"
+      mode="$2"
+      shift 2
+      ;;
+    --repo-root)
+      need_arg "$@"
+      repo_root="$2"
+      shift 2
+      ;;
+    --worktree-path)
+      need_arg "$@"
+      worktree_path="$2"
+      shift 2
+      ;;
+    --window-id)
+      need_arg "$@"
+      window_id="$2"
+      shift 2
+      ;;
+    --pane-id)
+      need_arg "$@"
+      pane_id="$2"
+      shift 2
+      ;;
+    --root)
+      need_arg "$@"
+      state_root="$2"
+      shift 2
+      ;;
+    --session-id)
+      need_arg "$@"
+      session_id="$2"
+      shift 2
+      ;;
+    -h | --help | help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'error: unknown argument: %s\n' "$1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$mode" in
+  dispatch | orchestrate | window-bootstrap) ;;
+  *)
+    printf 'error: unsupported mode: %s\n' "$mode" >&2
+    exit 2
+    ;;
+esac
+
+tmux_available="no"
+in_tmux="no"
+codex_available="no"
+jq_available="no"
+orch_available="no"
+orch_status="degraded"
+state_root_writable="no"
+repo_root_ok="unknown"
+worktree_match="unknown"
+window_exists_flag="no"
+pane_exists_flag="no"
+session_id_present="no"
+
+if has_cmd tmux; then
+  tmux_available="yes"
+fi
+if [ -n "${TMUX:-}" ] && [ "$tmux_available" = "yes" ]; then
+  in_tmux="yes"
+fi
+if has_cmd codex; then
+  codex_available="yes"
+fi
+if has_cmd jq; then
+  jq_available="yes"
+fi
+if [ "$jq_available" = "yes" ] && [ -x "$orch_bin" ]; then
+  orch_available="yes"
+  orch_status="enabled"
+fi
+
+if [ -n "$session_id" ]; then
+  session_id_present="yes"
+  if [ -n "${CODEX_SESSION_ID:-}" ] && [ "$session_id" = "${CODEX_SESSION_ID:-}" ]; then
+    session_id_source="CODEX_SESSION_ID"
+  elif [ -n "${CODEX_THREAD_ID:-}" ] && [ "$session_id" = "${CODEX_THREAD_ID:-}" ]; then
+    session_id_source="CODEX_THREAD_ID"
+  else
+    session_id_source="explicit"
+  fi
+fi
+
+[ -n "$worktree_path" ] || worktree_path="$PWD"
+if [ -d "$worktree_path" ] && has_cmd git; then
+  inferred_repo_root="$(git -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [ -z "$repo_root" ] && [ -n "$inferred_repo_root" ]; then
+    repo_root="$inferred_repo_root"
+  fi
+fi
+if [ -n "$repo_root" ] && has_cmd git; then
+  resolved_repo_root="$(git -C "$repo_root" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [ -n "$resolved_repo_root" ]; then
+    repo_root="$resolved_repo_root"
+    repo_root_ok="yes"
+  else
+    repo_root_ok="no"
+  fi
+fi
+if [ -n "$repo_root" ] && [ -n "$worktree_path" ] && has_cmd git; then
+  repo_common_dir="$(git -C "$repo_root" rev-parse --git-common-dir 2>/dev/null || true)"
+  worktree_common_dir="$(git -C "$worktree_path" rev-parse --git-common-dir 2>/dev/null || true)"
+  if [ -n "$repo_common_dir" ] && [ -n "$worktree_common_dir" ] && [ "$repo_common_dir" = "$worktree_common_dir" ]; then
+    worktree_match="yes"
+  elif [ -n "$repo_common_dir" ] || [ -n "$worktree_common_dir" ]; then
+    worktree_match="no"
+  fi
+fi
+
+[ -n "$window_id" ] || window_id="$(tmux_safe_display '#{window_id}')"
+[ -n "$pane_id" ] || pane_id="$(tmux_safe_display '#{pane_id}')"
+if window_exists "$window_id"; then
+  window_exists_flag="yes"
+fi
+if pane_exists "$pane_id"; then
+  pane_exists_flag="yes"
+fi
+
+[ -n "$state_root" ] || state_root="$(default_state_root)"
+state_parent="$(first_existing_dir "$state_root")"
+if [ -w "$state_parent" ]; then
+  state_root_writable="yes"
+fi
+
+required_ready="yes"
+optional_ready="yes"
+can_dispatch_lane="yes"
+can_manage_lifecycle="yes"
+blockers=()
+warnings=()
+
+if [ "$tmux_available" != "yes" ]; then
+  blockers+=("tmux_missing")
+fi
+if [ "$in_tmux" != "yes" ]; then
+  blockers+=("not_in_tmux")
+fi
+if [ "$codex_available" != "yes" ]; then
+  blockers+=("codex_missing")
+fi
+if [ "$session_id_present" != "yes" ]; then
+  blockers+=("session_id_missing")
+fi
+if [ "$window_exists_flag" != "yes" ]; then
+  blockers+=("window_unresolved")
+fi
+if [ "$pane_exists_flag" != "yes" ]; then
+  blockers+=("pane_unresolved")
+fi
+if [ "$mode" = "window-bootstrap" ] && [ "${repo_root_ok:-no}" != "yes" ]; then
+  blockers+=("repo_root_invalid")
+fi
+
+if [ "$orch_available" != "yes" ]; then
+  warnings+=("orch_unavailable")
+fi
+if [ "$state_root_writable" != "yes" ]; then
+  warnings+=("state_root_not_writable")
+fi
+if [ "$repo_root_ok" = "no" ]; then
+  warnings+=("repo_root_invalid")
+fi
+if [ "$worktree_match" = "no" ]; then
+  warnings+=("worktree_outside_repo_root")
+fi
+
+if [ "${#blockers[@]}" -gt 0 ]; then
+  required_ready="no"
+  can_dispatch_lane="no"
+  can_manage_lifecycle="no"
+fi
+
+if [ "$orch_available" != "yes" ] || [ "$state_root_writable" != "yes" ]; then
+  optional_ready="no"
+  can_manage_lifecycle="no"
+fi
+
+printf '## Preflight\n'
+printf -- '- mode: %s\n' "$mode"
+printf -- '- helper_root: %s\n' "$script_dir"
+printf -- '- orch_bin: %s\n' "$orch_bin"
+printf -- '- repo_root: %s\n' "${repo_root:-n/a}"
+printf -- '- worktree_path: %s\n' "${worktree_path:-n/a}"
+printf -- '- session_name: %s\n' "$(tmux_safe_display '#S' || true)"
+printf -- '- window_id: %s\n' "${window_id:-n/a}"
+printf -- '- pane_id: %s\n' "${pane_id:-n/a}"
+printf -- '- session_id_present: %s\n' "$session_id_present"
+printf -- '- session_id_source: %s\n' "$session_id_source"
+printf -- '- state_root: %s\n' "$state_root"
+
+printf '\n## Required Checks\n'
+printf -- '- tmux_available: %s\n' "$tmux_available"
+printf -- '- in_tmux: %s\n' "$in_tmux"
+printf -- '- codex_available: %s\n' "$codex_available"
+printf -- '- window_exists: %s\n' "$window_exists_flag"
+printf -- '- pane_exists: %s\n' "$pane_exists_flag"
+printf -- '- repo_root_ok: %s\n' "$repo_root_ok"
+printf -- '- required_ready: %s\n' "$required_ready"
+
+printf '\n## Optional Checks\n'
+printf -- '- jq_available: %s\n' "$jq_available"
+printf -- '- orch_available: %s\n' "$orch_available"
+printf -- '- orch_status: %s\n' "$orch_status"
+printf -- '- state_root_writable: %s\n' "$state_root_writable"
+printf -- '- worktree_match: %s\n' "$worktree_match"
+printf -- '- optional_ready: %s\n' "$optional_ready"
+
+printf '\n## Capabilities\n'
+printf -- '- can_dispatch_lane: %s\n' "$can_dispatch_lane"
+printf -- '- can_manage_lifecycle: %s\n' "$can_manage_lifecycle"
+
+printf '\n## Findings\n'
+if [ "${#blockers[@]}" -gt 0 ]; then
+  printf -- '- blockers: %s\n' "$(IFS=,; printf '%s' "${blockers[*]}")"
+else
+  printf -- '- blockers: none\n'
+fi
+if [ "${#warnings[@]}" -gt 0 ]; then
+  printf -- '- warnings: %s\n' "$(IFS=,; printf '%s' "${warnings[*]}")"
+else
+  printf -- '- warnings: none\n'
+fi
+
+if [ "$required_ready" = "yes" ]; then
+  exit 0
+fi
+exit 1

--- a/tmux/bin/tmux-task-lane-bootstrap
+++ b/tmux/bin/tmux-task-lane-bootstrap
@@ -363,7 +363,7 @@ if [ "$orch_enabled" = "yes" ]; then
     --forked-from-pane-id "$orchestrator_pane_id" >/dev/null
 fi
 
-fork_profile="gpt-5.4-mini / medium / fast"
+fork_profile="gpt-5.4-mini / xhigh / fast"
 fork_cmd="TMUX_ORCH_ROOT=$(printf '%q' "$state_root") codex fork $(printf '%q' "$session_id") --cd $(printf '%q' "$worktree_path") --no-alt-screen"
 case "$role" in
   coder | reviewer)
@@ -371,8 +371,8 @@ case "$role" in
     fork_cmd="$fork_cmd -m gpt-5.4 -c model_reasoning_effort=xhigh"
     ;;
   issue-gate)
-    fork_profile="gpt-5.4-mini / medium / fast"
-    fork_cmd="$fork_cmd -m gpt-5.4-mini -c model_reasoning_effort=medium -c service_tier=fast"
+    fork_profile="gpt-5.4-mini / xhigh / fast"
+    fork_cmd="$fork_cmd -m gpt-5.4-mini -c model_reasoning_effort=xhigh -c service_tier=fast"
     ;;
 esac
 prompt="$(build_lane_prompt "$role" "$task_context" "$phase" "$dispatcher_skill" "$fork_profile" "$window_id" "$new_pane_id" "$orchestrator_pane_id" "$state_root" "$orch_status")"

--- a/tmux/bin/tmux-task-lane-bootstrap
+++ b/tmux/bin/tmux-task-lane-bootstrap
@@ -367,8 +367,8 @@ fork_profile="gpt-5.4-mini / medium / fast"
 fork_cmd="TMUX_ORCH_ROOT=$(printf '%q' "$state_root") codex fork $(printf '%q' "$session_id") --cd $(printf '%q' "$worktree_path") --no-alt-screen"
 case "$role" in
   coder | reviewer)
-    fork_profile="gpt-5.4 / xhigh / flex"
-    fork_cmd="$fork_cmd -m gpt-5.4 -c model_reasoning_effort=xhigh -c service_tier=flex"
+    fork_profile="gpt-5.4 / xhigh"
+    fork_cmd="$fork_cmd -m gpt-5.4 -c model_reasoning_effort=xhigh"
     ;;
   issue-gate)
     fork_profile="gpt-5.4-mini / medium / fast"

--- a/tmux/bin/tmux-task-lane-bootstrap
+++ b/tmux/bin/tmux-task-lane-bootstrap
@@ -47,6 +47,14 @@ tmux_session_name() {
   tmux display-message -p '#S'
 }
 
+first_existing_dir() {
+  local path="$1"
+  while [ ! -e "$path" ] && [ "$path" != "/" ]; do
+    path="$(dirname "$path")"
+  done
+  printf '%s\n' "$path"
+}
+
 default_state_root() {
   local base session
   base="${TMUX_ORCH_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/tmux-orch}"
@@ -68,14 +76,45 @@ default_layout_for_role() {
   esac
 }
 
+shell_like_command() {
+  case "$1" in
+    bash | zsh | sh | fish | nu | dash) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+pane_ready_for_prompt() {
+  local pane_id="$1"
+  local current_command=""
+  current_command="$(tmux display-message -p -t "$pane_id" '#{pane_current_command}' 2>/dev/null || true)"
+  [ -n "$current_command" ] || return 1
+  if [ "$current_command" = "codex" ] || [ "$current_command" = "node" ]; then
+    return 0
+  fi
+  shell_like_command "$current_command" && return 1
+  return 0
+}
+
+pane_looks_like_codex() {
+  local pane_id="$1"
+  local snapshot=""
+  snapshot="$(tmux capture-pane -p -t "$pane_id" -S -80 2>/dev/null || true)"
+  printf '%s' "$snapshot" | rg -q "OpenAI Codex|Model:|Permissions:|Context window:"
+}
+
+state_root_is_writable() {
+  local root="$1"
+  local parent
+  parent="$(first_existing_dir "$root")"
+  [ -w "$parent" ]
+}
+
 wait_for_codex_ready() {
   local pane_id="$1"
   local max_attempts="${2:-80}"
   local attempt=0
-  local current_command=""
   while [ "$attempt" -lt "$max_attempts" ]; do
-    current_command="$(tmux display-message -p -t "$pane_id" '#{pane_current_command}' 2>/dev/null || true)"
-    if [ "$current_command" = "codex" ]; then
+    if pane_ready_for_prompt "$pane_id" || pane_looks_like_codex "$pane_id"; then
       return 0
     fi
     sleep 0.25
@@ -289,6 +328,10 @@ fi
 [ -n "$worktree_path" ] || worktree_path="$(tmux display-message -p -t "$target_pane" '#{pane_current_path}')"
 [ -n "$layout" ] || layout="$(default_layout_for_role "$role")"
 [ -n "$state_root" ] || state_root="$(default_state_root)"
+if [ "$orch_enabled" = "yes" ] && ! state_root_is_writable "$state_root"; then
+  orch_enabled="no"
+  orch_status="degraded"
+fi
 
 split_flag="-v"
 [ "$layout" = "h" ] && split_flag="-h"
@@ -326,7 +369,12 @@ if wait_for_codex_ready "$new_pane_id"; then
   send_startup_prompt "$new_pane_id" "$prompt"
   fork_status="ready-and-prompted"
 else
-  fork_status="fork-timeout"
+  if pane_ready_for_prompt "$new_pane_id" || pane_looks_like_codex "$new_pane_id"; then
+    send_startup_prompt "$new_pane_id" "$prompt"
+    fork_status="ready-after-timeout"
+  else
+    fork_status="fork-timeout"
+  fi
 fi
 
 printf '## Lane Bootstrap\n'

--- a/tmux/bin/tmux-task-lane-bootstrap
+++ b/tmux/bin/tmux-task-lane-bootstrap
@@ -76,23 +76,12 @@ default_layout_for_role() {
   esac
 }
 
-shell_like_command() {
-  case "$1" in
-    bash | zsh | sh | fish | nu | dash) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
 pane_ready_for_prompt() {
   local pane_id="$1"
   local current_command=""
   current_command="$(tmux display-message -p -t "$pane_id" '#{pane_current_command}' 2>/dev/null || true)"
   [ -n "$current_command" ] || return 1
-  if [ "$current_command" = "codex" ] || [ "$current_command" = "node" ]; then
-    return 0
-  fi
-  shell_like_command "$current_command" && return 1
-  return 0
+  [ "$current_command" = "codex" ]
 }
 
 pane_looks_like_codex() {
@@ -130,6 +119,45 @@ send_startup_prompt() {
   tmux send-keys -t "$pane_id" Enter
 }
 
+pane_contains_marker() {
+  local pane_id="$1"
+  local marker="$2"
+  local snapshot=""
+  snapshot="$(tmux capture-pane -p -t "$pane_id" -S -200 2>/dev/null || true)"
+  printf '%s' "$snapshot" | rg -F -q -- "$marker"
+}
+
+wait_for_prompt_marker() {
+  local pane_id="$1"
+  local marker="$2"
+  local max_attempts="${3:-20}"
+  local attempt=0
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    if pane_contains_marker "$pane_id" "$marker"; then
+      return 0
+    fi
+    sleep 0.25
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+send_startup_prompt_confirmed() {
+  local pane_id="$1"
+  local marker="$2"
+  local message="$3"
+  local attempt=0
+  while [ "$attempt" -lt 2 ]; do
+    send_startup_prompt "$pane_id" "$message"
+    if wait_for_prompt_marker "$pane_id" "$marker"; then
+      return 0
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
 build_lane_prompt() {
   local role="$1"
   local task_context="$2"
@@ -145,6 +173,7 @@ build_lane_prompt() {
   case "$role" in
     coder)
       cat <<EOF
+[tmux-lane-bootstrap coder]
 You are the coder lane for this task window.
 This lane was dispatched by $dispatcher_skill.
 Task context: $task_context
@@ -175,6 +204,7 @@ EOF
       ;;
     issue-gate)
       cat <<EOF
+[tmux-lane-bootstrap issue-gate]
 You are the issue-gate lane for this task window.
 This lane was dispatched by $dispatcher_skill.
 Task context: $task_context
@@ -205,6 +235,7 @@ EOF
       ;;
     reviewer)
       cat <<EOF
+[tmux-lane-bootstrap reviewer]
 You are the reviewer lane for this task window.
 This lane was dispatched by $dispatcher_skill.
 Task context: $task_context
@@ -376,15 +407,22 @@ case "$role" in
     ;;
 esac
 prompt="$(build_lane_prompt "$role" "$task_context" "$phase" "$dispatcher_skill" "$fork_profile" "$window_id" "$new_pane_id" "$orchestrator_pane_id" "$state_root" "$orch_status")"
+prompt_marker="[tmux-lane-bootstrap $role]"
 tmux send-keys -t "$new_pane_id" "$fork_cmd" C-m
 fork_status="fork-dispatched"
 if wait_for_codex_ready "$new_pane_id"; then
-  send_startup_prompt "$new_pane_id" "$prompt"
-  fork_status="ready-and-prompted"
+  if send_startup_prompt_confirmed "$new_pane_id" "$prompt_marker" "$prompt"; then
+    fork_status="ready-and-prompted"
+  else
+    fork_status="ready-prompt-unconfirmed"
+  fi
 else
   if pane_ready_for_prompt "$new_pane_id" || pane_looks_like_codex "$new_pane_id"; then
-    send_startup_prompt "$new_pane_id" "$prompt"
-    fork_status="ready-after-timeout"
+    if send_startup_prompt_confirmed "$new_pane_id" "$prompt_marker" "$prompt"; then
+      fork_status="ready-after-timeout"
+    else
+      fork_status="ready-after-timeout-unconfirmed"
+    fi
   else
     fork_status="fork-timeout"
   fi

--- a/tmux/bin/tmux-task-lane-bootstrap
+++ b/tmux/bin/tmux-task-lane-bootstrap
@@ -11,6 +11,7 @@ Usage:
     --role ROLE \
     --task-context TEXT \
     [--phase NAME] \
+    [--dispatcher-skill NAME] \
     [--target-pane PANE_ID] \
     [--orchestrator-pane-id PANE_ID] \
     [--window-id WINDOW_ID] \
@@ -94,17 +95,18 @@ build_lane_prompt() {
   local role="$1"
   local task_context="$2"
   local phase="$3"
-  local window_id="$4"
-  local pane_id="$5"
-  local orchestrator_pane_id="$6"
-  local state_root="$7"
-  local orch_status="$8"
+  local dispatcher_skill="$4"
+  local window_id="$5"
+  local pane_id="$6"
+  local orchestrator_pane_id="$7"
+  local state_root="$8"
+  local orch_status="$9"
 
   case "$role" in
     coder)
       cat <<EOF
 You are the coder lane for this task window.
-This lane was dispatched by \$tmux-task-orchestrator-skill.
+This lane was dispatched by $dispatcher_skill.
 Task context: $task_context
 Phase: $phase
 Window id: $window_id
@@ -133,7 +135,7 @@ EOF
     issue-gate)
       cat <<EOF
 You are the issue-gate lane for this task window.
-This lane was dispatched by \$tmux-task-orchestrator-skill.
+This lane was dispatched by $dispatcher_skill.
 Task context: $task_context
 Phase: $phase
 Window id: $window_id
@@ -162,7 +164,7 @@ EOF
     reviewer)
       cat <<EOF
 You are the reviewer lane for this task window.
-This lane was dispatched by \$tmux-task-orchestrator-skill.
+This lane was dispatched by $dispatcher_skill.
 Task context: $task_context
 Phase: $phase
 Window id: $window_id
@@ -197,6 +199,7 @@ EOF
 role=""
 task_context=""
 phase="phase1"
+dispatcher_skill='$tmux-task-orchestrator-skill'
 target_pane="${TMUX_PANE:-}"
 orchestrator_pane_id="${TMUX_PANE:-}"
 window_id=""
@@ -218,6 +221,10 @@ while [ $# -gt 0 ]; do
       ;;
     --phase)
       phase="$2"
+      shift 2
+      ;;
+    --dispatcher-skill)
+      dispatcher_skill="$2"
       shift 2
       ;;
     --target-pane)
@@ -310,7 +317,7 @@ if [ "$orch_enabled" = "yes" ]; then
     --forked-from-pane-id "$orchestrator_pane_id" >/dev/null
 fi
 
-prompt="$(build_lane_prompt "$role" "$task_context" "$phase" "$window_id" "$new_pane_id" "$orchestrator_pane_id" "$state_root" "$orch_status")"
+prompt="$(build_lane_prompt "$role" "$task_context" "$phase" "$dispatcher_skill" "$window_id" "$new_pane_id" "$orchestrator_pane_id" "$state_root" "$orch_status")"
 printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen' \
   "$state_root" "$session_id" "$worktree_path"
 tmux send-keys -t "$new_pane_id" "$fork_cmd" C-m

--- a/tmux/bin/tmux-task-lane-bootstrap
+++ b/tmux/bin/tmux-task-lane-bootstrap
@@ -117,6 +117,8 @@ send_startup_prompt() {
   local message="$2"
   tmux send-keys -t "$pane_id" -l "$message"
   tmux send-keys -t "$pane_id" Enter
+  sleep 0.2
+  tmux send-keys -t "$pane_id" Enter
 }
 
 pane_contains_marker() {

--- a/tmux/bin/tmux-task-lane-bootstrap
+++ b/tmux/bin/tmux-task-lane-bootstrap
@@ -23,9 +23,9 @@ Roles:
   coder | issue-gate | reviewer
 
 Notes:
-  - Requires tmux, jq, and a current Codex session id.
+  - Requires tmux and a current Codex session id.
   - Creates one non-orchestrator lane pane, runs bare `codex fork`, then sends a role-specific prompt after readiness is confirmed.
-  - Registers the pane in tmux-orch and updates tmux window role options.
+  - Registers the pane in tmux-orch when jq and tmux-orch are available; otherwise continues in tmux-only fallback mode.
 EOF
 }
 
@@ -36,6 +36,10 @@ fail() {
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
 }
 
 tmux_session_name() {
@@ -94,6 +98,7 @@ build_lane_prompt() {
   local pane_id="$5"
   local orchestrator_pane_id="$6"
   local state_root="$7"
+  local orch_status="$8"
 
   case "$role" in
     coder)
@@ -106,7 +111,9 @@ Window id: $window_id
 Your pane id: $pane_id
 Orchestrator pane id: $orchestrator_pane_id
 State root: $state_root
-Do not redefine scope. Implement only the assigned slice, run the smallest relevant checks, then send a structured handoff back to the orchestrator pane and append the same handoff to tmux-orch.
+tmux-orch durable state: $orch_status
+Do not redefine scope. Implement only the assigned slice, run the smallest relevant checks, then send a structured handoff back to the orchestrator pane.
+If tmux-orch is available, append the same handoff there. If it is unavailable, continue in tmux-only degraded mode and report that state in your handoff.
 
 Required handoff message envelope:
 [handoff][coder->orchestrator]
@@ -116,10 +123,10 @@ checks_run: <list>
 risks: <list>
 request: <next action request>
 
-If your runtime status changes, refresh your pane record:
+If tmux-orch is available and your runtime status changes, refresh your pane record:
 tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$pane_id" --role coder --scope phase --phase "$phase" --status <active|blocked|idle> --forked-from-session-id "${CODEX_SESSION_ID:-${CODEX_THREAD_ID:-}}"
 
-Append the matching durable handoff:
+If tmux-orch is available, append the matching durable handoff:
 tmux/bin/orch handoff --root "$state_root" --window-id "$window_id" --phase "$phase" --from-pane-id "$pane_id" --to-pane-id "$orchestrator_pane_id" --from-role coder --to-role orchestrator --type <status> --payload-json '{"changed_files":[],"checks_run":[],"risks":[],"request":""}'
 EOF
       ;;
@@ -133,7 +140,9 @@ Window id: $window_id
 Your pane id: $pane_id
 Orchestrator pane id: $orchestrator_pane_id
 State root: $state_root
+tmux-orch durable state: $orch_status
 Confirm issue traceability, draft or refine the issue when needed, and return a structured handoff with the issue outcome, refs line, and whether human confirmation is still needed.
+If tmux-orch is unavailable, continue in tmux-only degraded mode and report that state in your handoff.
 
 Required handoff message envelope:
 [handoff][issue-gate->orchestrator]
@@ -143,10 +152,10 @@ refs_line: <ISSUE: #... or n/a>
 risks: <list>
 request: <next action request>
 
-If your runtime status changes, refresh your pane record:
+If tmux-orch is available and your runtime status changes, refresh your pane record:
 tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$pane_id" --role issue-gate --scope phase --phase "$phase" --status <active|blocked|idle> --forked-from-session-id "${CODEX_SESSION_ID:-${CODEX_THREAD_ID:-}}"
 
-Append the matching durable handoff:
+If tmux-orch is available, append the matching durable handoff:
 tmux/bin/orch handoff --root "$state_root" --window-id "$window_id" --phase "$phase" --from-pane-id "$pane_id" --to-pane-id "$orchestrator_pane_id" --from-role issue-gate --to-role orchestrator --type <status> --payload-json '{"issue_ref":"","refs_line":"","risks":[],"request":""}'
 EOF
       ;;
@@ -160,7 +169,9 @@ Window id: $window_id
 Your pane id: $pane_id
 Orchestrator pane id: $orchestrator_pane_id
 State root: $state_root
+tmux-orch durable state: $orch_status
 Review findings first. Do not edit implementation unless explicitly reassigned. Return one of approved, fix-now, or follow-up with concrete findings.
+If tmux-orch is unavailable, continue in tmux-only degraded mode and report that state in your handoff.
 
 Required handoff message envelope:
 [handoff][reviewer->orchestrator]
@@ -170,10 +181,10 @@ checks_run: <list>
 risks: <list>
 request: <next action request>
 
-If your runtime status changes, refresh your pane record:
+If tmux-orch is available and your runtime status changes, refresh your pane record:
 tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$pane_id" --role reviewer --scope phase --phase "$phase" --status <active|blocked|idle> --forked-from-session-id "${CODEX_SESSION_ID:-${CODEX_THREAD_ID:-}}"
 
-Append the matching durable handoff:
+If tmux-orch is available, append the matching durable handoff:
 tmux/bin/orch handoff --root "$state_root" --window-id "$window_id" --phase "$phase" --from-pane-id "$pane_id" --to-pane-id "$orchestrator_pane_id" --from-role reviewer --to-role orchestrator --type <status> --payload-json '{"findings":[],"checks_run":[],"risks":[],"request":""}'
 EOF
       ;;
@@ -259,8 +270,13 @@ done
 [ -n "$session_id" ] || fail "missing CODEX_SESSION_ID/CODEX_THREAD_ID; pass --session-id explicitly"
 
 need_cmd tmux
-need_cmd jq
-[ -x "$orch_bin" ] || fail "missing executable orch at $orch_bin"
+
+orch_enabled="no"
+orch_status="degraded"
+if has_cmd jq && [ -x "$orch_bin" ]; then
+  orch_enabled="yes"
+  orch_status="enabled"
+fi
 
 [ -n "$window_id" ] || window_id="$(tmux display-message -p -t "$orchestrator_pane_id" '#{window_id}')"
 [ -n "$worktree_path" ] || worktree_path="$(tmux display-message -p -t "$target_pane" '#{pane_current_path}')"
@@ -280,19 +296,21 @@ tmux set -wq -t "$window_id" "@pane_$(role_option_key "$role")" "$new_pane_id"
 tmux set -pt "$orchestrator_pane_id" @user_pane_title "orchestrator"
 tmux set -pt "$new_pane_id" @user_pane_title "$role"
 
-"$orch_bin" init --root "$state_root" >/dev/null
-"$orch_bin" register-pane \
-  --root "$state_root" \
-  --window-id "$window_id" \
-  --pane-id "$new_pane_id" \
-  --role "$role" \
-  --scope phase \
-  --phase "$phase" \
-  --status "$status" \
-  --forked-from-session-id "$session_id" \
-  --forked-from-pane-id "$orchestrator_pane_id" >/dev/null
+if [ "$orch_enabled" = "yes" ]; then
+  "$orch_bin" init --root "$state_root" >/dev/null
+  "$orch_bin" register-pane \
+    --root "$state_root" \
+    --window-id "$window_id" \
+    --pane-id "$new_pane_id" \
+    --role "$role" \
+    --scope phase \
+    --phase "$phase" \
+    --status "$status" \
+    --forked-from-session-id "$session_id" \
+    --forked-from-pane-id "$orchestrator_pane_id" >/dev/null
+fi
 
-prompt="$(build_lane_prompt "$role" "$task_context" "$phase" "$window_id" "$new_pane_id" "$orchestrator_pane_id" "$state_root")"
+prompt="$(build_lane_prompt "$role" "$task_context" "$phase" "$window_id" "$new_pane_id" "$orchestrator_pane_id" "$state_root" "$orch_status")"
 printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen' \
   "$state_root" "$session_id" "$worktree_path"
 tmux send-keys -t "$new_pane_id" "$fork_cmd" C-m
@@ -311,4 +329,5 @@ printf -- '- pane_id: %s\n' "$new_pane_id"
 printf -- '- orchestrator_pane_id: %s\n' "$orchestrator_pane_id"
 printf -- '- worktree_path: %s\n' "$worktree_path"
 printf -- '- state_root: %s\n' "$state_root"
+printf -- '- tmux_orch_status: %s\n' "$orch_status"
 printf -- '- fork_status: %s\n' "$fork_status"

--- a/tmux/bin/tmux-task-lane-bootstrap
+++ b/tmux/bin/tmux-task-lane-bootstrap
@@ -135,11 +135,12 @@ build_lane_prompt() {
   local task_context="$2"
   local phase="$3"
   local dispatcher_skill="$4"
-  local window_id="$5"
-  local pane_id="$6"
-  local orchestrator_pane_id="$7"
-  local state_root="$8"
-  local orch_status="$9"
+  local fork_profile="$5"
+  local window_id="$6"
+  local pane_id="$7"
+  local orchestrator_pane_id="$8"
+  local state_root="$9"
+  local orch_status="${10}"
 
   case "$role" in
     coder)
@@ -148,6 +149,7 @@ You are the coder lane for this task window.
 This lane was dispatched by $dispatcher_skill.
 Task context: $task_context
 Phase: $phase
+Fork profile: $fork_profile
 Window id: $window_id
 Your pane id: $pane_id
 Orchestrator pane id: $orchestrator_pane_id
@@ -177,6 +179,7 @@ You are the issue-gate lane for this task window.
 This lane was dispatched by $dispatcher_skill.
 Task context: $task_context
 Phase: $phase
+Fork profile: $fork_profile
 Window id: $window_id
 Your pane id: $pane_id
 Orchestrator pane id: $orchestrator_pane_id
@@ -360,9 +363,19 @@ if [ "$orch_enabled" = "yes" ]; then
     --forked-from-pane-id "$orchestrator_pane_id" >/dev/null
 fi
 
-prompt="$(build_lane_prompt "$role" "$task_context" "$phase" "$dispatcher_skill" "$window_id" "$new_pane_id" "$orchestrator_pane_id" "$state_root" "$orch_status")"
-printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen' \
-  "$state_root" "$session_id" "$worktree_path"
+fork_profile="gpt-5.4-mini / medium / fast"
+fork_cmd="TMUX_ORCH_ROOT=$(printf '%q' "$state_root") codex fork $(printf '%q' "$session_id") --cd $(printf '%q' "$worktree_path") --no-alt-screen"
+case "$role" in
+  coder | reviewer)
+    fork_profile="gpt-5.4 / xhigh / flex"
+    fork_cmd="$fork_cmd -m gpt-5.4 -c model_reasoning_effort=xhigh -c service_tier=flex"
+    ;;
+  issue-gate)
+    fork_profile="gpt-5.4-mini / medium / fast"
+    fork_cmd="$fork_cmd -m gpt-5.4-mini -c model_reasoning_effort=medium -c service_tier=fast"
+    ;;
+esac
+prompt="$(build_lane_prompt "$role" "$task_context" "$phase" "$dispatcher_skill" "$fork_profile" "$window_id" "$new_pane_id" "$orchestrator_pane_id" "$state_root" "$orch_status")"
 tmux send-keys -t "$new_pane_id" "$fork_cmd" C-m
 fork_status="fork-dispatched"
 if wait_for_codex_ready "$new_pane_id"; then

--- a/tmux/bin/tmux-task-lane-bootstrap
+++ b/tmux/bin/tmux-task-lane-bootstrap
@@ -24,7 +24,7 @@ Roles:
 
 Notes:
   - Requires tmux, jq, and a current Codex session id.
-  - Creates one non-orchestrator lane pane and injects a role-specific prompt.
+  - Creates one non-orchestrator lane pane, runs bare `codex fork`, then sends a role-specific prompt after readiness is confirmed.
   - Registers the pane in tmux-orch and updates tmux window role options.
 EOF
 }
@@ -61,6 +61,29 @@ default_layout_for_role() {
     issue-gate | reviewer) printf 'v' ;;
     *) printf 'v' ;;
   esac
+}
+
+wait_for_codex_ready() {
+  local pane_id="$1"
+  local max_attempts="${2:-80}"
+  local attempt=0
+  local current_command=""
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    current_command="$(tmux display-message -p -t "$pane_id" '#{pane_current_command}' 2>/dev/null || true)"
+    if [ "$current_command" = "codex" ]; then
+      return 0
+    fi
+    sleep 0.25
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+send_startup_prompt() {
+  local pane_id="$1"
+  local message="$2"
+  tmux send-keys -t "$pane_id" -l "$message"
+  tmux send-keys -t "$pane_id" Enter
 }
 
 build_lane_prompt() {
@@ -270,9 +293,16 @@ tmux set -pt "$new_pane_id" @user_pane_title "$role"
   --forked-from-pane-id "$orchestrator_pane_id" >/dev/null
 
 prompt="$(build_lane_prompt "$role" "$task_context" "$phase" "$window_id" "$new_pane_id" "$orchestrator_pane_id" "$state_root")"
-printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q %q --cd %q --no-alt-screen' \
-  "$state_root" "$session_id" "$prompt" "$worktree_path"
+printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen' \
+  "$state_root" "$session_id" "$worktree_path"
 tmux send-keys -t "$new_pane_id" "$fork_cmd" C-m
+fork_status="fork-dispatched"
+if wait_for_codex_ready "$new_pane_id"; then
+  send_startup_prompt "$new_pane_id" "$prompt"
+  fork_status="ready-and-prompted"
+else
+  fork_status="fork-timeout"
+fi
 
 printf '## Lane Bootstrap\n'
 printf -- '- role: %s\n' "$role"
@@ -281,3 +311,4 @@ printf -- '- pane_id: %s\n' "$new_pane_id"
 printf -- '- orchestrator_pane_id: %s\n' "$orchestrator_pane_id"
 printf -- '- worktree_path: %s\n' "$worktree_path"
 printf -- '- state_root: %s\n' "$state_root"
+printf -- '- fork_status: %s\n' "$fork_status"

--- a/tmux/bin/tmux-task-window-bootstrap
+++ b/tmux/bin/tmux-task-window-bootstrap
@@ -23,7 +23,7 @@ Usage:
 Notes:
   - Requires tmux, git, jq, and a current Codex session id.
   - Uses $TMUX_ORCH_ROOT or the default tmux-orch session root when --root is omitted.
-  - Injects a prompt that tells the child session to continue as $tmux-task-orchestrator-skill.
+  - Uses a two-step startup: bare `codex fork`, then a startup prompt after the pane is ready.
 EOF
 }
 
@@ -62,6 +62,29 @@ shell_like_command() {
     bash | zsh | sh | fish | nu | dash) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+wait_for_codex_ready() {
+  local pane_id="$1"
+  local max_attempts="${2:-80}"
+  local attempt=0
+  local current_command=""
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    current_command="$(tmux display-message -p -t "$pane_id" '#{pane_current_command}' 2>/dev/null || true)"
+    if [ "$current_command" = "codex" ]; then
+      return 0
+    fi
+    sleep 0.25
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+send_startup_prompt() {
+  local pane_id="$1"
+  local message="$2"
+  tmux send-keys -t "$pane_id" -l "$message"
+  tmux send-keys -t "$pane_id" Enter
 }
 
 repo_root=""
@@ -172,14 +195,14 @@ window_info="$(
     '
 )"
 
-fork_status="dispatched"
+fork_status="not-started"
 if [ -n "$window_info" ]; then
   window_id="$(printf '%s' "$window_info" | cut -f1)"
   window_name="$(printf '%s' "$window_info" | cut -f2)"
   orchestrator_pane_id="$(printf '%s' "$window_info" | cut -f3)"
   target_command="$(printf '%s' "$window_info" | cut -f5)"
   if shell_like_command "$target_command"; then
-    fork_status="dispatched-existing-window"
+    fork_status="window-ready"
   else
     fork_status="existing-window-busy"
   fi
@@ -233,13 +256,19 @@ EOF
 )"
 
 if [ "$fork_status" != "existing-window-busy" ]; then
-  printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q %q --cd %q --no-alt-screen' \
-    "$state_root" "$session_id" "$prompt" "$worktree_path"
+  printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen' \
+    "$state_root" "$session_id" "$worktree_path"
   tmux send-keys -t "$orchestrator_pane_id" "$fork_cmd" C-m
+  if wait_for_codex_ready "$orchestrator_pane_id"; then
+    send_startup_prompt "$orchestrator_pane_id" "$prompt"
+    fork_status="ready-and-prompted"
+  else
+    fork_status="fork-timeout"
+  fi
 fi
 
 handoff_ready="yes"
-if [ "$fork_status" = "existing-window-busy" ]; then
+if [ "$fork_status" = "existing-window-busy" ] || [ "$fork_status" = "fork-timeout" ]; then
   handoff_ready="no"
 fi
 

--- a/tmux/bin/tmux-task-window-bootstrap
+++ b/tmux/bin/tmux-task-window-bootstrap
@@ -299,7 +299,7 @@ Branch: $branch
 State root: $state_root
 Do not start implementation directly.
 tmux-orch durable state: $orch_status
-Fork profile: gpt-5.4-mini / medium / fast
+Fork profile: gpt-5.4-mini / xhigh / fast
 First confirm repo state and task context, register or refresh the task window in tmux-orch if it is available, decide the local phase and next action, and only then dispatch coder, reviewer, or issue work if needed.
 If tmux-orch is unavailable in this environment, continue in tmux-only degraded mode rather than blocking lane setup.
 When lane setup is needed, use \$tmux-task-lane-bootstrap-skill rather than creating panes ad hoc.
@@ -307,7 +307,7 @@ EOF
 )"
 
 if [ "$fork_status" != "existing-window-busy" ]; then
-  printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=medium -c service_tier=fast' \
+  printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=xhigh -c service_tier=fast' \
     "$state_root" "$session_id" "$worktree_path"
   tmux send-keys -t "$orchestrator_pane_id" "$fork_cmd" C-m
   if wait_for_codex_ready "$orchestrator_pane_id"; then

--- a/tmux/bin/tmux-task-window-bootstrap
+++ b/tmux/bin/tmux-task-window-bootstrap
@@ -45,6 +45,14 @@ tmux_session_name() {
   tmux display-message -p '#S'
 }
 
+first_existing_dir() {
+  local path="$1"
+  while [ ! -e "$path" ] && [ "$path" != "/" ]; do
+    path="$(dirname "$path")"
+  done
+  printf '%s\n' "$path"
+}
+
 default_state_root() {
   local base session
   base="${TMUX_ORCH_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/tmux-orch}"
@@ -69,14 +77,38 @@ shell_like_command() {
   esac
 }
 
+pane_ready_for_prompt() {
+  local pane_id="$1"
+  local current_command=""
+  current_command="$(tmux display-message -p -t "$pane_id" '#{pane_current_command}' 2>/dev/null || true)"
+  [ -n "$current_command" ] || return 1
+  if [ "$current_command" = "codex" ] || [ "$current_command" = "node" ]; then
+    return 0
+  fi
+  shell_like_command "$current_command" && return 1
+  return 0
+}
+
+pane_looks_like_codex() {
+  local pane_id="$1"
+  local snapshot=""
+  snapshot="$(tmux capture-pane -p -t "$pane_id" -S -80 2>/dev/null || true)"
+  printf '%s' "$snapshot" | rg -q "OpenAI Codex|Model:|Permissions:|Context window:"
+}
+
+state_root_is_writable() {
+  local root="$1"
+  local parent
+  parent="$(first_existing_dir "$root")"
+  [ -w "$parent" ]
+}
+
 wait_for_codex_ready() {
   local pane_id="$1"
   local max_attempts="${2:-80}"
   local attempt=0
-  local current_command=""
   while [ "$attempt" -lt "$max_attempts" ]; do
-    current_command="$(tmux display-message -p -t "$pane_id" '#{pane_current_command}' 2>/dev/null || true)"
-    if [ "$current_command" = "codex" ]; then
+    if pane_ready_for_prompt "$pane_id" || pane_looks_like_codex "$pane_id"; then
       return 0
     fi
     sleep 0.25
@@ -183,6 +215,10 @@ task_kind="$(slugify "$task_kind")"
 [ -n "$worktree_root" ] || worktree_root="$(dirname "$repo_root")/_worktrees"
 [ -n "$window_name" ] || window_name="wt-${task_slug}"
 [ -n "$state_root" ] || state_root="$(default_state_root)"
+if [ "$orch_enabled" = "yes" ] && ! state_root_is_writable "$state_root"; then
+  orch_enabled="no"
+  orch_status="degraded"
+fi
 
 branch="task/${task_kind}/$(date +%Y%m%d)-${task_slug}"
 worktree_path="${worktree_root}/${task_kind}-${task_slug}"
@@ -277,7 +313,12 @@ if [ "$fork_status" != "existing-window-busy" ]; then
     send_startup_prompt "$orchestrator_pane_id" "$prompt"
     fork_status="ready-and-prompted"
   else
-    fork_status="fork-timeout"
+    if pane_ready_for_prompt "$orchestrator_pane_id" || pane_looks_like_codex "$orchestrator_pane_id"; then
+      send_startup_prompt "$orchestrator_pane_id" "$prompt"
+      fork_status="ready-after-timeout"
+    else
+      fork_status="fork-timeout"
+    fi
   fi
 fi
 

--- a/tmux/bin/tmux-task-window-bootstrap
+++ b/tmux/bin/tmux-task-window-bootstrap
@@ -299,6 +299,7 @@ Branch: $branch
 State root: $state_root
 Do not start implementation directly.
 tmux-orch durable state: $orch_status
+Fork profile: gpt-5.4-mini / medium / fast
 First confirm repo state and task context, register or refresh the task window in tmux-orch if it is available, decide the local phase and next action, and only then dispatch coder, reviewer, or issue work if needed.
 If tmux-orch is unavailable in this environment, continue in tmux-only degraded mode rather than blocking lane setup.
 When lane setup is needed, use \$tmux-task-lane-bootstrap-skill rather than creating panes ad hoc.
@@ -306,7 +307,7 @@ EOF
 )"
 
 if [ "$fork_status" != "existing-window-busy" ]; then
-  printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen' \
+  printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=medium -c service_tier=fast' \
     "$state_root" "$session_id" "$worktree_path"
   tmux send-keys -t "$orchestrator_pane_id" "$fork_cmd" C-m
   if wait_for_codex_ready "$orchestrator_pane_id"; then

--- a/tmux/bin/tmux-task-window-bootstrap
+++ b/tmux/bin/tmux-task-window-bootstrap
@@ -70,23 +70,12 @@ slugify() {
   printf '%.48s' "$value"
 }
 
-shell_like_command() {
-  case "$1" in
-    bash | zsh | sh | fish | nu | dash) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
 pane_ready_for_prompt() {
   local pane_id="$1"
   local current_command=""
   current_command="$(tmux display-message -p -t "$pane_id" '#{pane_current_command}' 2>/dev/null || true)"
   [ -n "$current_command" ] || return 1
-  if [ "$current_command" = "codex" ] || [ "$current_command" = "node" ]; then
-    return 0
-  fi
-  shell_like_command "$current_command" && return 1
-  return 0
+  [ "$current_command" = "codex" ]
 }
 
 pane_looks_like_codex() {
@@ -122,6 +111,45 @@ send_startup_prompt() {
   local message="$2"
   tmux send-keys -t "$pane_id" -l "$message"
   tmux send-keys -t "$pane_id" Enter
+}
+
+pane_contains_marker() {
+  local pane_id="$1"
+  local marker="$2"
+  local snapshot=""
+  snapshot="$(tmux capture-pane -p -t "$pane_id" -S -200 2>/dev/null || true)"
+  printf '%s' "$snapshot" | rg -F -q -- "$marker"
+}
+
+wait_for_prompt_marker() {
+  local pane_id="$1"
+  local marker="$2"
+  local max_attempts="${3:-20}"
+  local attempt=0
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    if pane_contains_marker "$pane_id" "$marker"; then
+      return 0
+    fi
+    sleep 0.25
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+send_startup_prompt_confirmed() {
+  local pane_id="$1"
+  local marker="$2"
+  local message="$3"
+  local attempt=0
+  while [ "$attempt" -lt 2 ]; do
+    send_startup_prompt "$pane_id" "$message"
+    if wait_for_prompt_marker "$pane_id" "$marker"; then
+      return 0
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+  return 1
 }
 
 repo_root=""
@@ -291,6 +319,7 @@ if [ "$orch_enabled" = "yes" ]; then
 fi
 
 prompt="$(cat <<EOF
+[tmux-window-bootstrap orchestrator]
 Continue in this new worktree as \$tmux-task-orchestrator-skill for this task.
 Task context: $task_context
 Repo root: $repo_root
@@ -305,18 +334,25 @@ If tmux-orch is unavailable in this environment, continue in tmux-only degraded 
 When lane setup is needed, use \$tmux-task-lane-bootstrap-skill rather than creating panes ad hoc.
 EOF
 )"
+prompt_marker="[tmux-window-bootstrap orchestrator]"
 
 if [ "$fork_status" != "existing-window-busy" ]; then
   printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=xhigh -c service_tier=fast' \
     "$state_root" "$session_id" "$worktree_path"
   tmux send-keys -t "$orchestrator_pane_id" "$fork_cmd" C-m
   if wait_for_codex_ready "$orchestrator_pane_id"; then
-    send_startup_prompt "$orchestrator_pane_id" "$prompt"
-    fork_status="ready-and-prompted"
+    if send_startup_prompt_confirmed "$orchestrator_pane_id" "$prompt_marker" "$prompt"; then
+      fork_status="ready-and-prompted"
+    else
+      fork_status="ready-prompt-unconfirmed"
+    fi
   else
     if pane_ready_for_prompt "$orchestrator_pane_id" || pane_looks_like_codex "$orchestrator_pane_id"; then
-      send_startup_prompt "$orchestrator_pane_id" "$prompt"
-      fork_status="ready-after-timeout"
+      if send_startup_prompt_confirmed "$orchestrator_pane_id" "$prompt_marker" "$prompt"; then
+        fork_status="ready-after-timeout"
+      else
+        fork_status="ready-after-timeout-unconfirmed"
+      fi
     else
       fork_status="fork-timeout"
     fi
@@ -324,7 +360,7 @@ if [ "$fork_status" != "existing-window-busy" ]; then
 fi
 
 handoff_ready="yes"
-if [ "$fork_status" = "existing-window-busy" ] || [ "$fork_status" = "fork-timeout" ]; then
+if [ "$fork_status" = "existing-window-busy" ] || [ "$fork_status" = "fork-timeout" ] || [ "$fork_status" = "ready-prompt-unconfirmed" ] || [ "$fork_status" = "ready-after-timeout-unconfirmed" ]; then
   handoff_ready="no"
 fi
 

--- a/tmux/bin/tmux-task-window-bootstrap
+++ b/tmux/bin/tmux-task-window-bootstrap
@@ -21,8 +21,9 @@ Usage:
     [--session-id ID]
 
 Notes:
-  - Requires tmux, git, jq, and a current Codex session id.
+  - Requires tmux, git, and a current Codex session id.
   - Uses $TMUX_ORCH_ROOT or the default tmux-orch session root when --root is omitted.
+  - Uses tmux-only fallback mode when jq or tmux-orch is unavailable.
   - Uses a two-step startup: bare `codex fork`, then a startup prompt after the pane is ready.
 EOF
 }
@@ -34,6 +35,10 @@ fail() {
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
 }
 
 tmux_session_name() {
@@ -162,8 +167,13 @@ done
 
 need_cmd tmux
 need_cmd git
-need_cmd jq
-[ -x "$orch_bin" ] || fail "missing executable orch at $orch_bin"
+
+orch_enabled="no"
+orch_status="degraded"
+if has_cmd jq && [ -x "$orch_bin" ]; then
+  orch_enabled="yes"
+  orch_status="enabled"
+fi
 
 repo_root="$(git -C "$repo_root" rev-parse --show-toplevel)"
 [ -n "$base_branch" ] || base_branch="$(git -C "$repo_root" symbolic-ref --quiet --short HEAD)"
@@ -218,29 +228,31 @@ fi
 tmux set -wq -t "$window_id" @pane_orchestrator "$orchestrator_pane_id"
 tmux set -pt "$orchestrator_pane_id" @user_pane_title "orchestrator"
 
-"$orch_bin" init --root "$state_root" --project "$(basename "$repo_root")" >/dev/null
-"$orch_bin" register-window \
-  --root "$state_root" \
-  --window-id "$window_id" \
-  --window-name "$window_name" \
-  --repo-root "$repo_root" \
-  --worktree-path "$worktree_path" \
-  --branch "$branch" \
-  --task "$task_context" \
-  --phase "$phase" \
-  --status "$status" \
-  --next-action "confirm-local-plan" \
-  --review-status pending \
-  --commit-status pending \
-  --merge-status not_ready \
-  --owner-orchestrator-pane-id "$orchestrator_pane_id" >/dev/null
-"$orch_bin" register-pane \
-  --root "$state_root" \
-  --window-id "$window_id" \
-  --pane-id "$orchestrator_pane_id" \
-  --role orchestrator \
-  --scope window \
-  --status active >/dev/null
+if [ "$orch_enabled" = "yes" ]; then
+  "$orch_bin" init --root "$state_root" --project "$(basename "$repo_root")" >/dev/null
+  "$orch_bin" register-window \
+    --root "$state_root" \
+    --window-id "$window_id" \
+    --window-name "$window_name" \
+    --repo-root "$repo_root" \
+    --worktree-path "$worktree_path" \
+    --branch "$branch" \
+    --task "$task_context" \
+    --phase "$phase" \
+    --status "$status" \
+    --next-action "confirm-local-plan" \
+    --review-status pending \
+    --commit-status pending \
+    --merge-status not_ready \
+    --owner-orchestrator-pane-id "$orchestrator_pane_id" >/dev/null
+  "$orch_bin" register-pane \
+    --root "$state_root" \
+    --window-id "$window_id" \
+    --pane-id "$orchestrator_pane_id" \
+    --role orchestrator \
+    --scope window \
+    --status active >/dev/null
+fi
 
 prompt="$(cat <<EOF
 Continue in this new worktree as \$tmux-task-orchestrator-skill for this task.
@@ -250,7 +262,9 @@ Worktree path: $worktree_path
 Branch: $branch
 State root: $state_root
 Do not start implementation directly.
-First confirm repo state and task context, register or refresh the task window in tmux-orch, decide the local phase and next action, and only then dispatch coder, reviewer, or issue work if needed.
+tmux-orch durable state: $orch_status
+First confirm repo state and task context, register or refresh the task window in tmux-orch if it is available, decide the local phase and next action, and only then dispatch coder, reviewer, or issue work if needed.
+If tmux-orch is unavailable in this environment, continue in tmux-only degraded mode rather than blocking lane setup.
 When lane setup is needed, use \$tmux-task-lane-bootstrap-skill rather than creating panes ad hoc.
 EOF
 )"
@@ -282,5 +296,6 @@ printf -- '- orchestrator_pane_id: %s\n' "$orchestrator_pane_id"
 printf -- '- worktree_created: %s\n' "$worktree_created"
 printf '\n## Verification\n'
 printf -- '- window_exists: yes\n'
+printf -- '- tmux_orch_status: %s\n' "$orch_status"
 printf -- '- fork_status: %s\n' "$fork_status"
 printf -- '- handoff_ready: %s\n' "$handoff_ready"

--- a/tmux/bin/tmux-task-window-bootstrap
+++ b/tmux/bin/tmux-task-window-bootstrap
@@ -111,6 +111,8 @@ send_startup_prompt() {
   local message="$2"
   tmux send-keys -t "$pane_id" -l "$message"
   tmux send-keys -t "$pane_id" Enter
+  sleep 0.2
+  tmux send-keys -t "$pane_id" Enter
 }
 
 pane_contains_marker() {

--- a/tmux/skills/tmux-lane-dispatch-skill/SKILL.md
+++ b/tmux/skills/tmux-lane-dispatch-skill/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: tmux-lane-dispatch-skill
+description: v0.1.0 - Public fast path for dispatching one task-local lane with minimal preflight, without entering full task lifecycle orchestration.
+---
+
+# Tmux Lane Dispatch Skill
+
+## Overview
+
+This role is the thin public entrypoint for quick lane dispatch.
+
+It exists for the common case where the user wants to start one coder,
+reviewer, or issue-gate lane without paying the full cost of task lifecycle
+orchestration.
+
+## Trigger and Scope
+
+Use this skill when the goal is:
+
+- create one lane quickly
+- keep the current pane as the local control point
+- stop after the lane is ready and prompted
+
+Do not use this skill when the goal is to manage review, commit, merge-back, or
+task lifecycle state over time. In those cases, use
+`$tmux-task-orchestrator-skill`.
+
+In scope:
+
+- run `tmux-orch-preflight`
+- resolve the current tmux pane/window context
+- dispatch one lane through `tmux-dispatch-lane`
+- return the resolved pane map and fork status
+
+Out of scope:
+
+- deciding review or commit readiness
+- running tests or repo diagnostics beyond preflight
+- managing `next_action` across a long-lived task window
+- merge-back or project-level handoff
+
+## Required Inputs
+
+- `task_context`
+
+## Optional Inputs
+
+- `role`: default `coder`
+- `phase`
+- `worktree_path`
+- `window_id`
+- `orchestrator_pane_id`
+
+## Fixed Defaults
+
+- `entry_mode=dispatch-fast-path`
+- `preflight_mode=dispatch`
+- `lane_role_default=coder`
+- `post_dispatch_policy=stop-after-pane-ready`
+
+## Workflow
+
+1. Resolve current `window_id`, `pane_id`, and `worktree_path`.
+2. Run `tmux/bin/tmux-orch-preflight --mode dispatch`.
+3. If required checks fail, stop and report the blockers.
+4. If required checks pass, call `tmux/bin/tmux-dispatch-lane`.
+5. Return the created pane id, fork status, and durable-state mode.
+6. Stop. Do not continue into review, commit, or merge logic.
+
+## Guardrails
+
+- Do not expand into full lifecycle orchestration from this role.
+- Do not run reviewer or commit logic unless the user explicitly switches to
+  `$tmux-task-orchestrator-skill`.
+- Do not recreate pane mechanics inline; use `tmux/bin/tmux-dispatch-lane`.
+- Treat degraded mode as usable for dispatch only when preflight says
+  `can_dispatch_lane=yes`.
+
+## References
+
+- `../tmux-task-lane-bootstrap-skill/SKILL.md`
+- `../tmux-task-orchestrator-skill/SKILL.md`
+
+## Output Format
+
+```text
+## Dispatch
+- role:
+- task_context:
+- window_id:
+- orchestrator_pane:
+
+## Verification
+- preflight_required_ready:
+- preflight_optional_ready:
+- can_dispatch_lane:
+- fork_status:
+
+## Pane Map
+- orchestrator_pane:
+- dispatched_pane:
+
+## Handoff
+- next_owner:
+- note:
+```

--- a/tmux/skills/tmux-project-orchestrator-skill/SKILL.md
+++ b/tmux/skills/tmux-project-orchestrator-skill/SKILL.md
@@ -346,9 +346,9 @@ Reference:
 6. If a new task window is required:
    - call `$tmux-task-window-bootstrap-skill`
    - preserve the current `TMUX_ORCH_ROOT`
-   - instruct the forked session to continue as
-     `$tmux-task-orchestrator-skill`
-   - make the downstream prompt explicitly require:
+   - use a bare `codex fork` first, then send the startup prompt only after the
+     child pane is ready
+   - make the downstream startup prompt explicitly require:
      - use `$tmux-task-orchestrator-skill`
      - do not start implementation directly
      - register or refresh the task window in `tmux-orch`
@@ -360,6 +360,7 @@ Reference:
    - the target tmux window exists
    - `window_name` and `window_id` are known
    - the fork command has been dispatched into that window
+   - the startup prompt has been sent only after the child pane is ready
    - `handoff_ready=yes` only after those checks pass
 8. When a task window becomes the active focus, let
    `$tmux-task-orchestrator-skill` own:

--- a/tmux/skills/tmux-project-orchestrator-skill/SKILL.md
+++ b/tmux/skills/tmux-project-orchestrator-skill/SKILL.md
@@ -73,6 +73,7 @@ Requires explicit human approval when policy is unclear or impact is broad:
 - start from project state, not from whichever pane is loudest
 - keep one visible owner for every active task window
 - drive decisions through explicit `next_action` and window status
+- do not invoke helper skills unless the current node explicitly requires them
 - hand task-local execution to `$tmux-task-orchestrator-skill`
 - use `$tmux-task-window-bootstrap-skill` for worktree/window creation instead of
   inlining bootstrap mechanics into this role
@@ -216,6 +217,17 @@ Out of scope:
 - per-pane `tmux split-window` mechanics
 - coder/reviewer/issue-gate lane work itself
 - replacing tmux runtime routing with JSON state
+
+## Subskill Trigger Nodes
+
+Only trigger another skill when the current node matches one of these cases:
+
+- `next_action=create-task-window`
+  - use `$tmux-task-window-bootstrap-skill`
+- `next_action=handoff-task-window`
+  - use `$tmux-task-orchestrator-skill`
+
+Do not trigger task-local lane or commit skills directly from the project role.
 
 ## Core Purpose
 

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
@@ -81,7 +81,9 @@ Out of scope:
    - `window_id`, current `pane_id`, `orchestrator_pane_id`, and `TMUX_ORCH_ROOT`
    - the required handoff message envelope
    - how the lane should refresh its own pane status and append a matching
-     handoff in `tmux-orch`
+     handoff in `tmux-orch` when available
+   - how the lane should continue in tmux-only degraded mode when durable state
+     registration is unavailable
 9. Return the resolved pane map to the task-window orchestrator.
 
 ## References

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmux-task-lane-bootstrap-skill
-description: v0.1.2 - Internal helper that realizes lane layout, lane startup, pane_id registration, and phase-scoped lane retirement inside one task window after task-level orchestration has already chosen the next local action.
+description: v0.1.3 - Internal helper that realizes lane layout, lane startup, pane_id registration, and phase-scoped lane retirement inside one task window after task-level orchestration has already chosen the next local action.
 ---
 
 # Tmux Task Lane Bootstrap Skill
@@ -53,7 +53,7 @@ Out of scope:
 
 - `routing_key=pane_id`
 - `phase_scope=non-orchestrator-lanes`
-- `message_mode=literal-double-enter`
+- `message_mode=literal-enter`
 - `execution_mode=lane-bootstrap-only`
 
 ## Guardrails
@@ -61,6 +61,8 @@ Out of scope:
 - Do not use this skill as the public task owner.
 - Do not decide project or task policy here; realize the already chosen lane plan.
 - In Codex TUI flows, do not add `--full-auto` to child `codex fork` commands.
+- Do not embed the lane startup prompt directly in the `codex fork` command;
+  send it only after fork readiness is confirmed.
 - Use tmux `pane_id` as the only machine routing key.
 - Use a dedicated reviewer pane for formal review.
 
@@ -71,14 +73,16 @@ Out of scope:
 3. Create, refresh, or retire panes as instructed by that plan.
 4. Capture each pane's `pane_id` immediately.
 5. Register panes and fork provenance in `tmux-orch` when used.
-6. Fork child lanes from the current orchestrator session.
-7. Send role-first prompts that include:
+6. Fork child lanes from the current orchestrator session without embedding the
+   startup prompt in the `codex fork` command.
+7. Confirm the child pane has entered Codex.
+8. Send role-first prompts that include:
    - current role and task context
    - `window_id`, current `pane_id`, `orchestrator_pane_id`, and `TMUX_ORCH_ROOT`
    - the required handoff message envelope
    - how the lane should refresh its own pane status and append a matching
      handoff in `tmux-orch`
-8. Return the resolved pane map to the task-window orchestrator.
+9. Return the resolved pane map to the task-window orchestrator.
 
 ## References
 

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
@@ -7,9 +7,12 @@ description: v0.1.3 - Internal helper that realizes lane layout, lane startup, p
 
 ## Trigger and Scope
 
-Use this skill only as an internal helper when
-`$tmux-task-orchestrator-skill` has already decided that the current task
-window needs lane realization, lane refresh, or phase-scoped pane retirement.
+Use this skill only as an internal helper when either:
+
+- `$tmux-task-orchestrator-skill` has already decided that the current task
+  window needs lane realization, lane refresh, or phase-scoped pane retirement
+- `$tmux-lane-dispatch-skill` has already decided that one lane should be
+  started through the fast dispatch path
 
 This skill is not a public role.
 
@@ -28,6 +31,7 @@ Out of scope:
 - deciding whether issue-gate/reviewer/commit is needed in the abstract
 - commit-stage or merge-back decisions
 - direct implementation
+- public fast-path intent selection
 
 ## Required Inputs
 
@@ -69,7 +73,7 @@ Out of scope:
 ## Workflow
 
 1. Confirm the current task window and current orchestrator pane.
-2. Read the lane plan already chosen by `$tmux-task-orchestrator-skill`.
+2. Read the lane plan already chosen by the caller.
 3. Create, refresh, or retire panes as instructed by that plan.
 4. Capture each pane's `pane_id` immediately.
 5. Register panes and fork provenance in `tmux-orch` when used.
@@ -84,7 +88,7 @@ Out of scope:
      handoff in `tmux-orch` when available
    - how the lane should continue in tmux-only degraded mode when durable state
      registration is unavailable
-9. Return the resolved pane map to the task-window orchestrator.
+9. Return the resolved pane map to the calling role.
 
 ## References
 

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
@@ -59,7 +59,7 @@ Out of scope:
 - `phase_scope=non-orchestrator-lanes`
 - `message_mode=literal-enter`
 - `execution_mode=lane-bootstrap-only`
-- `coder/reviewer fork profile=gpt-5.4/xhigh/flex`
+- `coder/reviewer fork profile=gpt-5.4/xhigh`
 - `issue-gate fork profile=gpt-5.4-mini/medium/fast`
 
 ## Guardrails
@@ -68,8 +68,8 @@ Out of scope:
 - Do not decide project or task policy here; realize the already chosen lane plan.
 - In Codex TUI flows, do not add `--full-auto` to child `codex fork` commands.
 - For coder and reviewer lanes, override the fork to `gpt-5.4` with
-  `model_reasoning_effort=xhigh` and `service_tier=flex` so they do not inherit
-  the lightweight orchestrator profile.
+  `model_reasoning_effort=xhigh` so they do not inherit the lightweight
+  orchestrator profile.
 - For issue-gate lanes, explicitly use `gpt-5.4-mini` with
   `model_reasoning_effort=medium` and `service_tier=fast`.
 - Do not embed the lane startup prompt directly in the `codex fork` command;

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
@@ -59,12 +59,19 @@ Out of scope:
 - `phase_scope=non-orchestrator-lanes`
 - `message_mode=literal-enter`
 - `execution_mode=lane-bootstrap-only`
+- `coder/reviewer fork profile=gpt-5.4/xhigh/flex`
+- `issue-gate fork profile=gpt-5.4-mini/medium/fast`
 
 ## Guardrails
 
 - Do not use this skill as the public task owner.
 - Do not decide project or task policy here; realize the already chosen lane plan.
 - In Codex TUI flows, do not add `--full-auto` to child `codex fork` commands.
+- For coder and reviewer lanes, override the fork to `gpt-5.4` with
+  `model_reasoning_effort=xhigh` and `service_tier=flex` so they do not inherit
+  the lightweight orchestrator profile.
+- For issue-gate lanes, explicitly use `gpt-5.4-mini` with
+  `model_reasoning_effort=medium` and `service_tier=fast`.
 - Do not embed the lane startup prompt directly in the `codex fork` command;
   send it only after fork readiness is confirmed.
 - Use tmux `pane_id` as the only machine routing key.

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
@@ -57,7 +57,7 @@ Out of scope:
 
 - `routing_key=pane_id`
 - `phase_scope=non-orchestrator-lanes`
-- `message_mode=literal-enter`
+- `message_mode=literal-double-enter-confirmed`
 - `execution_mode=lane-bootstrap-only`
 - `coder/reviewer fork profile=gpt-5.4/xhigh`
 - `issue-gate fork profile=gpt-5.4-mini/xhigh/fast`
@@ -74,6 +74,8 @@ Out of scope:
   `model_reasoning_effort=xhigh` and `service_tier=fast`.
 - Do not embed the lane startup prompt directly in the `codex fork` command;
   send it only after fork readiness is confirmed.
+- Submit the lane startup prompt with literal paste, then two `Enter`
+  keystrokes, then confirm delivery from the child pane transcript.
 - Treat prompt delivery as confirmed only after a visible marker appears in the
   child pane transcript; do not report `ready-and-prompted` on process start
   alone.
@@ -90,7 +92,8 @@ Out of scope:
 6. Fork child lanes from the current orchestrator session without embedding the
    startup prompt in the `codex fork` command.
 7. Confirm the child pane has entered Codex.
-8. Send role-first prompts that include:
+8. Send role-first prompts with literal paste, two `Enter` keystrokes, and
+   transcript confirmation. The prompt must include:
    - current role and task context
    - `window_id`, current `pane_id`, `orchestrator_pane_id`, and `TMUX_ORCH_ROOT`
    - the required handoff message envelope

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
@@ -60,7 +60,7 @@ Out of scope:
 - `message_mode=literal-enter`
 - `execution_mode=lane-bootstrap-only`
 - `coder/reviewer fork profile=gpt-5.4/xhigh`
-- `issue-gate fork profile=gpt-5.4-mini/medium/fast`
+- `issue-gate fork profile=gpt-5.4-mini/xhigh/fast`
 
 ## Guardrails
 
@@ -71,7 +71,7 @@ Out of scope:
   `model_reasoning_effort=xhigh` so they do not inherit the lightweight
   orchestrator profile.
 - For issue-gate lanes, explicitly use `gpt-5.4-mini` with
-  `model_reasoning_effort=medium` and `service_tier=fast`.
+  `model_reasoning_effort=xhigh` and `service_tier=fast`.
 - Do not embed the lane startup prompt directly in the `codex fork` command;
   send it only after fork readiness is confirmed.
 - Use tmux `pane_id` as the only machine routing key.

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
@@ -74,6 +74,9 @@ Out of scope:
   `model_reasoning_effort=xhigh` and `service_tier=fast`.
 - Do not embed the lane startup prompt directly in the `codex fork` command;
   send it only after fork readiness is confirmed.
+- Treat prompt delivery as confirmed only after a visible marker appears in the
+  child pane transcript; do not report `ready-and-prompted` on process start
+  alone.
 - Use tmux `pane_id` as the only machine routing key.
 - Use a dedicated reviewer pane for formal review.
 

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
@@ -17,7 +17,8 @@ tmux/bin/tmux-task-lane-bootstrap --role coder --task-context "..." --phase phas
 - create the pane layout for one task window
 - capture canonical `pane_id` values immediately
 - fork non-orchestrator panes from the current orchestrator session
-- send role-first startup prompts after fork readiness is confirmed
+- send role-first startup prompts after fork readiness is confirmed, using
+  literal paste plus two `Enter` keystrokes before transcript confirmation
 - keep tmux window options and `tmux-orch` pane state aligned
 
 ## Required Rules
@@ -34,7 +35,7 @@ tmux/bin/tmux-task-lane-bootstrap --role coder --task-context "..." --phase phas
 - for issue-gate lanes, explicitly use `gpt-5.4-mini` with
   `model_reasoning_effort=xhigh` and `service_tier=fast`
 - do not embed startup prompts directly in `codex fork`; fork first, verify the
-  child pane is in Codex, then send the prompt
+  child pane is in Codex, then send the prompt with two `Enter` keystrokes
 - after sending the prompt, confirm delivery by checking for a short marker in
   the pane transcript before reporting `ready-and-prompted`
 - use a dedicated reviewer pane for formal review
@@ -95,6 +96,8 @@ Suggested send pattern:
 ```bash
 message="$(printf 'You are the coder lane for this task window.\nThe task plan is already decided by $tmux-task-orchestrator-skill.\nRole: coder\nWindow id: %s\nYour pane id: %s\nOrchestrator pane id: %s\nState root: %s\nBefore returning control, refresh your pane status if needed, send a structured handoff message to the orchestrator pane, and append the same handoff to tmux-orch.\nReport changed files, checks run, risks, and a clear request for the next action.' \"$window_id\" \"$coder_pane\" \"$orch_pane\" \"$state_root\")"
 tmux send-keys -t "$coder_pane" -l "$message"
+tmux send-keys -t "$coder_pane" Enter
+sleep 0.2
 tmux send-keys -t "$coder_pane" Enter
 ```
 

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
@@ -35,6 +35,8 @@ tmux/bin/tmux-task-lane-bootstrap --role coder --task-context "..." --phase phas
   `model_reasoning_effort=xhigh` and `service_tier=fast`
 - do not embed startup prompts directly in `codex fork`; fork first, verify the
   child pane is in Codex, then send the prompt
+- after sending the prompt, confirm delivery by checking for a short marker in
+  the pane transcript before reporting `ready-and-prompted`
 - use a dedicated reviewer pane for formal review
 - recreate phase-scoped panes across phase boundaries
 

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
@@ -32,7 +32,7 @@ tmux/bin/tmux-task-lane-bootstrap --role coder --task-context "..." --phase phas
   with `model_reasoning_effort=xhigh` so they do not inherit the lightweight
   orchestrator profile
 - for issue-gate lanes, explicitly use `gpt-5.4-mini` with
-  `model_reasoning_effort=medium` and `service_tier=fast`
+  `model_reasoning_effort=xhigh` and `service_tier=fast`
 - do not embed startup prompts directly in `codex fork`; fork first, verify the
   child pane is in Codex, then send the prompt
 - use a dedicated reviewer pane for formal review
@@ -66,7 +66,7 @@ tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane
 
 printf -v coder_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4 -c model_reasoning_effort=xhigh' \
   "$state_root" "$orchestrator_session_id" "$worktree_path"
-printf -v issue_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=medium -c service_tier=fast' \
+printf -v issue_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=xhigh -c service_tier=fast' \
   "$state_root" "$orchestrator_session_id" "$worktree_path"
 tmux send-keys -t "$coder_pane" "$coder_fork" C-m
 tmux send-keys -t "$issue_pane" "$issue_fork" C-m

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
@@ -29,8 +29,8 @@ tmux/bin/tmux-task-lane-bootstrap --role coder --task-context "..." --phase phas
   let the parent session's current permission model carry through unless an
   explicit override is truly intended
 - for coder and reviewer lanes, explicitly override the fork to `gpt-5.4`
-  with `model_reasoning_effort=xhigh` and `service_tier=flex` so they do not
-  inherit the lightweight orchestrator profile
+  with `model_reasoning_effort=xhigh` so they do not inherit the lightweight
+  orchestrator profile
 - for issue-gate lanes, explicitly use `gpt-5.4-mini` with
   `model_reasoning_effort=medium` and `service_tier=fast`
 - do not embed startup prompts directly in `codex fork`; fork first, verify the
@@ -64,7 +64,7 @@ tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane
 tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$coder_pane" --role coder --scope phase --phase phase1 --status active --forked-from-session-id "$orchestrator_session_id"
 tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$issue_pane" --role issue-gate --scope phase --phase phase1 --status active --forked-from-session-id "$orchestrator_session_id"
 
-printf -v coder_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4 -c model_reasoning_effort=xhigh -c service_tier=flex' \
+printf -v coder_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4 -c model_reasoning_effort=xhigh' \
   "$state_root" "$orchestrator_session_id" "$worktree_path"
 printf -v issue_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=medium -c service_tier=fast' \
   "$state_root" "$orchestrator_session_id" "$worktree_path"

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
@@ -17,7 +17,7 @@ tmux/bin/tmux-task-lane-bootstrap --role coder --task-context "..." --phase phas
 - create the pane layout for one task window
 - capture canonical `pane_id` values immediately
 - fork non-orchestrator panes from the current orchestrator session
-- send role-first startup prompts
+- send role-first startup prompts after fork readiness is confirmed
 - keep tmux window options and `tmux-orch` pane state aligned
 
 ## Required Rules
@@ -28,6 +28,8 @@ tmux/bin/tmux-task-lane-bootstrap --role coder --task-context "..." --phase phas
 - in Codex TUI mode, do not add `--full-auto` to lane `codex fork` commands;
   let the parent session's current permission model carry through unless an
   explicit override is truly intended
+- do not embed startup prompts directly in `codex fork`; fork first, verify the
+  child pane is in Codex, then send the prompt
 - use a dedicated reviewer pane for formal review
 - recreate phase-scoped panes across phase boundaries
 
@@ -56,6 +58,21 @@ tmux set -pt "$issue_pane" @user_pane_title "issue-gate"
 tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$orch_pane" --role orchestrator --scope window --status active
 tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$coder_pane" --role coder --scope phase --phase phase1 --status active --forked-from-session-id "$orchestrator_session_id"
 tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$issue_pane" --role issue-gate --scope phase --phase phase1 --status active --forked-from-session-id "$orchestrator_session_id"
+
+printf -v coder_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen' \
+  "$state_root" "$orchestrator_session_id" "$worktree_path"
+printf -v issue_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen' \
+  "$state_root" "$orchestrator_session_id" "$worktree_path"
+tmux send-keys -t "$coder_pane" "$coder_fork" C-m
+tmux send-keys -t "$issue_pane" "$issue_fork" C-m
+for _ in $(seq 1 40); do
+  [ "$(tmux display-message -p -t "$coder_pane" '#{pane_current_command}')" = "codex" ] && break
+  sleep 0.25
+done
+for _ in $(seq 1 40); do
+  [ "$(tmux display-message -p -t "$issue_pane" '#{pane_current_command}')" = "codex" ] && break
+  sleep 0.25
+done
 ```
 
 ## Role-First Startup Messages
@@ -71,8 +88,6 @@ Suggested send pattern:
 ```bash
 message="$(printf 'You are the coder lane for this task window.\nThe task plan is already decided by $tmux-task-orchestrator-skill.\nRole: coder\nWindow id: %s\nYour pane id: %s\nOrchestrator pane id: %s\nState root: %s\nBefore returning control, refresh your pane status if needed, send a structured handoff message to the orchestrator pane, and append the same handoff to tmux-orch.\nReport changed files, checks run, risks, and a clear request for the next action.' \"$window_id\" \"$coder_pane\" \"$orch_pane\" \"$state_root\")"
 tmux send-keys -t "$coder_pane" -l "$message"
-tmux send-keys -t "$coder_pane" Enter
-sleep 0.2
 tmux send-keys -t "$coder_pane" Enter
 ```
 
@@ -126,8 +141,6 @@ tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane
 ```bash
 message="$(printf '[handoff][coder->orchestrator]\nstatus: review-ready\nchanged_files: app/service.py\nchecks_run: pytest -q\nrisks: none\nrequest: dispatch reviewer')"
 tmux send-keys -t "$orch_pane" -l "$message"
-tmux send-keys -t "$orch_pane" Enter
-sleep 0.2
 tmux send-keys -t "$orch_pane" Enter
 
 tmux/bin/orch handoff \

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
@@ -28,6 +28,11 @@ tmux/bin/tmux-task-lane-bootstrap --role coder --task-context "..." --phase phas
 - in Codex TUI mode, do not add `--full-auto` to lane `codex fork` commands;
   let the parent session's current permission model carry through unless an
   explicit override is truly intended
+- for coder and reviewer lanes, explicitly override the fork to `gpt-5.4`
+  with `model_reasoning_effort=xhigh` and `service_tier=flex` so they do not
+  inherit the lightweight orchestrator profile
+- for issue-gate lanes, explicitly use `gpt-5.4-mini` with
+  `model_reasoning_effort=medium` and `service_tier=fast`
 - do not embed startup prompts directly in `codex fork`; fork first, verify the
   child pane is in Codex, then send the prompt
 - use a dedicated reviewer pane for formal review
@@ -59,9 +64,9 @@ tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane
 tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$coder_pane" --role coder --scope phase --phase phase1 --status active --forked-from-session-id "$orchestrator_session_id"
 tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$issue_pane" --role issue-gate --scope phase --phase phase1 --status active --forked-from-session-id "$orchestrator_session_id"
 
-printf -v coder_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen' \
+printf -v coder_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4 -c model_reasoning_effort=xhigh -c service_tier=flex' \
   "$state_root" "$orchestrator_session_id" "$worktree_path"
-printf -v issue_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen' \
+printf -v issue_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=medium -c service_tier=fast' \
   "$state_root" "$orchestrator_session_id" "$worktree_path"
 tmux send-keys -t "$coder_pane" "$coder_fork" C-m
 tmux send-keys -t "$issue_pane" "$issue_fork" C-m

--- a/tmux/skills/tmux-task-orchestrator-skill/SKILL.md
+++ b/tmux/skills/tmux-task-orchestrator-skill/SKILL.md
@@ -35,6 +35,7 @@ Mission:
 Non-negotiables:
 
 - do not stop at pane setup
+- do not implement code, write patches, or edit files from the orchestrator pane
 - do not leave post-review or post-commit behavior implicit
 - do not self-approve formal review from the orchestrator pane
 - do not merge back silently
@@ -76,6 +77,9 @@ Requires explicit human or project-level approval when:
 - begin from current task state, not from raw pane activity
 - keep one explicit local owner for the task window
 - dispatch only the minimal active roles needed for the next step
+- if implementation is needed, stop at `dispatch-coder` and hand off
+  immediately; do not continue into direct implementation from the
+  orchestrator pane
 - convert every handoff into a visible `next_action`
 - do not invoke helper skills unless the current node explicitly requires them
 - use `$tmux-task-lane-bootstrap-skill` for lane realization instead of
@@ -407,7 +411,11 @@ Typical decision flow:
    - review
    - commit-stage work
    - merge-back preparation
-7. If lane setup is needed, use `$tmux-task-lane-bootstrap-skill`.
+7. If coding is needed, do not implement it here:
+   - set `next_action=dispatch-coder`
+   - hand off to `$tmux-task-lane-bootstrap-skill`
+   - wait for a coder handoff before taking another implementation step
+8. If lane setup is needed, use `$tmux-task-lane-bootstrap-skill`.
    The lane bootstrap prompt must tell each created pane:
    - its role
    - the current task context and phase
@@ -416,26 +424,26 @@ Typical decision flow:
    - how to refresh its own pane record and append a structured handoff in
      `tmux-orch` when available
    - how to continue in tmux-only degraded mode when durable state is unavailable
-8. When `coder`, `issue-gate`, or `reviewer` hands back a result:
+9. When `coder`, `issue-gate`, or `reviewer` hands back a result:
    - record the handoff
    - update `status`, `phase`, and `next_action`
    - decide the next local dispatch
-9. If `next_action=run-issue-gate` and no active `issue-gate` pane exists yet:
+10. If `next_action=run-issue-gate` and no active `issue-gate` pane exists yet:
    - dispatch `$tmux-task-lane-bootstrap-skill` to realize the `issue-gate` lane
    - do not escalate to human confirmation before the `issue-gate` lane has
      produced an actual lookup result or issue draft
-10. For commit-stage work:
+11. For commit-stage work:
    - use `$issue-gate-skill` when traceability still needs confirmation
    - use `$git-commit-skill` when the task is approved and ready to commit
    - keep commit success/failure visible in task state
    - return control to `$tmux-task-orchestrator-skill` after commit instead of
      treating commit completion as the end of the flow
-11. When the task reaches merge-back:
+12. When the task reaches merge-back:
    - use `tmux/bin/tmux-task-project-handoff`
    - never guess the upstream target by pane index or active pane
    - let the helper resolve the canonical project orchestrator pane and append
      the matching durable handoff
-12. After merge-back, mark the task complete and retire phase-scoped lanes.
+13. After merge-back, mark the task complete and retire phase-scoped lanes.
 
 ## Standard Manual Flow (Recommended)
 

--- a/tmux/skills/tmux-task-orchestrator-skill/SKILL.md
+++ b/tmux/skills/tmux-task-orchestrator-skill/SKILL.md
@@ -351,7 +351,7 @@ Typical decision flow:
 
 1. enter `$tmux-task-orchestrator-skill`
 2. inspect repo state, task context, current phase, and current pane map
-3. register or refresh the task window in `tmux-orch`
+3. register or refresh the task window in `tmux-orch` when available
 4. decide the local `next_action`
 5. if lanes are needed, call `$tmux-task-lane-bootstrap-skill`
 6. dispatch only the minimal active roles needed for the next phase
@@ -372,40 +372,44 @@ Typical decision flow:
    - resolve the current `state_root`
    - register or refresh the current window snapshot
    - set an explicit `next_action`
-4. Decide whether the current task window needs:
+4. If `tmux-orch` is unavailable:
+   - mark durable state as degraded rather than blocked
+   - continue with tmux-only lane realization and handoffs
+5. Decide whether the current task window needs:
    - lane setup
    - coding
    - review
    - commit-stage work
    - merge-back preparation
-5. If lane setup is needed, use `$tmux-task-lane-bootstrap-skill`.
+6. If lane setup is needed, use `$tmux-task-lane-bootstrap-skill`.
    The lane bootstrap prompt must tell each created pane:
    - its role
    - the current task context and phase
    - the orchestrator pane target
    - the required handoff envelope
    - how to refresh its own pane record and append a structured handoff in
-     `tmux-orch`
-6. When `coder`, `issue-gate`, or `reviewer` hands back a result:
+     `tmux-orch` when available
+   - how to continue in tmux-only degraded mode when durable state is unavailable
+7. When `coder`, `issue-gate`, or `reviewer` hands back a result:
    - record the handoff
    - update `status`, `phase`, and `next_action`
    - decide the next local dispatch
-7. If `next_action=run-issue-gate` and no active `issue-gate` pane exists yet:
+8. If `next_action=run-issue-gate` and no active `issue-gate` pane exists yet:
    - dispatch `$tmux-task-lane-bootstrap-skill` to realize the `issue-gate` lane
    - do not escalate to human confirmation before the `issue-gate` lane has
      produced an actual lookup result or issue draft
-8. For commit-stage work:
+9. For commit-stage work:
    - use `$issue-gate-skill` when traceability still needs confirmation
    - use `$git-commit-skill` when the task is approved and ready to commit
    - keep commit success/failure visible in task state
    - return control to `$tmux-task-orchestrator-skill` after commit instead of
      treating commit completion as the end of the flow
-9. When the task reaches merge-back:
+10. When the task reaches merge-back:
    - use `tmux/bin/tmux-task-project-handoff`
    - never guess the upstream target by pane index or active pane
    - let the helper resolve the canonical project orchestrator pane and append
      the matching durable handoff
-10. After merge-back, mark the task complete and retire phase-scoped lanes.
+11. After merge-back, mark the task complete and retire phase-scoped lanes.
 
 ## Standard Manual Flow (Recommended)
 
@@ -418,22 +422,26 @@ worktree_path="$(pwd)"
 branch="$(git -C "$worktree_path" branch --show-current)"
 state_root="${TMUX_ORCH_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/tmux-orch/${session_slug}}"
 
-tmux/bin/orch init --root "$state_root"
-tmux/bin/orch register-window \
-  --root "$state_root" \
-  --window-id "$window_id" \
-  --window-name "$window_name" \
-  --worktree-path "$worktree_path" \
-  --branch "$branch" \
-  --task "$task_context" \
-  --phase "phase1" \
-  --status "in_progress" \
-  --next-action "confirm-task-context" \
-  --review-status "pending" \
-  --commit-status "pending" \
-  --merge-status "not_ready"
+if command -v jq >/dev/null 2>&1 && [ -x tmux/bin/orch ]; then
+  tmux/bin/orch init --root "$state_root"
+  tmux/bin/orch register-window \
+    --root "$state_root" \
+    --window-id "$window_id" \
+    --window-name "$window_name" \
+    --worktree-path "$worktree_path" \
+    --branch "$branch" \
+    --task "$task_context" \
+    --phase "phase1" \
+    --status "in_progress" \
+    --next-action "confirm-task-context" \
+    --review-status "pending" \
+    --commit-status "pending" \
+    --merge-status "not_ready"
 
-tmux/bin/orch status --root "$state_root"
+  tmux/bin/orch status --root "$state_root"
+else
+  printf 'tmux-orch unavailable; continuing in tmux-only degraded mode\n'
+fi
 ```
 
 If lanes are required after local confirmation, follow

--- a/tmux/skills/tmux-task-orchestrator-skill/SKILL.md
+++ b/tmux/skills/tmux-task-orchestrator-skill/SKILL.md
@@ -14,6 +14,9 @@ the task context, decides the current local phase, dispatches lanes when
 needed, consumes handoffs, decides the next action, and drives the task through
 review, commit, merge-back preparation, and closure.
 
+If the user only wants to start one lane quickly, do not use this role. Use
+`$tmux-lane-dispatch-skill`.
+
 ## Core Principles
 
 - Own the whole task lifecycle, not just lane startup.
@@ -74,6 +77,7 @@ Requires explicit human or project-level approval when:
 - keep one explicit local owner for the task window
 - dispatch only the minimal active roles needed for the next step
 - convert every handoff into a visible `next_action`
+- do not invoke helper skills unless the current node explicitly requires them
 - use `$tmux-task-lane-bootstrap-skill` for lane realization instead of
   carrying all pane mechanics inline
 - when lanes are needed, pass a lane prompt contract so each child pane knows
@@ -208,6 +212,7 @@ Out of scope:
 - cross-window or project-level sequencing
 - direct code implementation as the default behavior
 - pretending pane setup is the whole role
+- lane-only fast dispatch; use `$tmux-lane-dispatch-skill`
 - replacing tmux runtime routing with JSON state
 
 ## Core Purpose
@@ -316,6 +321,7 @@ Reference:
 Typical local `next_action` values:
 
 - `confirm-task-context`
+- `run-preflight`
 - `setup-lanes`
 - `run-issue-gate`
 - `dispatch-coder`
@@ -326,20 +332,38 @@ Typical local `next_action` values:
 - `complete`
 - `blocked`
 
+## Subskill Trigger Nodes
+
+Only trigger another skill when the current node matches one of these cases:
+
+- `next_action=run-preflight`
+  - run `tmux/bin/tmux-orch-preflight`
+- `next_action=setup-lanes`
+  - use `$tmux-task-lane-bootstrap-skill`
+- `next_action=run-issue-gate`
+  - use `$issue-gate-skill`
+- `next_action=run-commit-stage`
+  - use `$git-commit-skill`
+- `next_action=prepare-merge-back`
+  - use `tmux/bin/tmux-task-project-handoff`
+
+Do not trigger helper skills outside these explicit nodes.
+
 Typical decision flow:
 
 1. confirm task context and local state
-2. if lanes are missing, dispatch `$tmux-task-lane-bootstrap-skill`
-3. if issue traceability is still unknown, dispatch `issue-gate`
-4. if implementation is needed, dispatch `coder`
-5. when coder reports `review-ready`, either:
+2. run preflight and determine whether lifecycle orchestration is usable
+3. if lanes are missing and lifecycle orchestration is still the chosen mode, dispatch `$tmux-task-lane-bootstrap-skill`
+4. if issue traceability is still unknown, dispatch `issue-gate`
+5. if implementation is needed, dispatch `coder`
+6. when coder reports `review-ready`, either:
    - dispatch `reviewer`, or
    - move directly to `run-commit-stage` for trivial/no-review paths
-6. when reviewer reports `approved`, dispatch commit-stage work explicitly
-7. after commit succeeds, use `tmux/bin/tmux-task-project-handoff` to mark the
+7. when reviewer reports `approved`, dispatch commit-stage work explicitly
+8. after commit succeeds, use `tmux/bin/tmux-task-project-handoff` to mark the
    window `merge-ready` or `merge-complete` and hand that status back to the
    project-level orchestrator
-8. after merge-back, mark the task window complete and retire phase-scoped
+9. after merge-back, mark the task window complete and retire phase-scoped
    lanes
 
 ## References
@@ -351,13 +375,14 @@ Typical decision flow:
 
 1. enter `$tmux-task-orchestrator-skill`
 2. inspect repo state, task context, current phase, and current pane map
-3. register or refresh the task window in `tmux-orch` when available
-4. decide the local `next_action`
-5. if lanes are needed, call `$tmux-task-lane-bootstrap-skill`
-6. dispatch only the minimal active roles needed for the next phase
-7. consume each handoff and turn it into an explicit next step
-8. run issue/commit/merge preparation explicitly rather than assuming it
-9. close or retire phase-scoped panes when the current phase is complete
+3. run preflight and decide whether lifecycle orchestration should continue
+4. register or refresh the task window in `tmux-orch` when available
+5. decide the local `next_action`
+6. trigger helper skills only from their explicit node
+7. dispatch only the minimal active roles needed for the next phase
+8. consume each handoff and turn it into an explicit next step
+9. run issue/commit/merge preparation explicitly rather than assuming it
+10. close or retire phase-scoped panes when the current phase is complete
 
 ## Workflow
 
@@ -368,20 +393,21 @@ Typical decision flow:
    - current branch
    - current phase
    - current blockers
-3. If `tmux-orch` exists:
+3. Run `tmux/bin/tmux-orch-preflight`.
+4. If `tmux-orch` exists:
    - resolve the current `state_root`
    - register or refresh the current window snapshot
    - set an explicit `next_action`
-4. If `tmux-orch` is unavailable:
+5. If `tmux-orch` is unavailable:
    - mark durable state as degraded rather than blocked
    - continue with tmux-only lane realization and handoffs
-5. Decide whether the current task window needs:
+6. Decide whether the current task window needs:
    - lane setup
    - coding
    - review
    - commit-stage work
    - merge-back preparation
-6. If lane setup is needed, use `$tmux-task-lane-bootstrap-skill`.
+7. If lane setup is needed, use `$tmux-task-lane-bootstrap-skill`.
    The lane bootstrap prompt must tell each created pane:
    - its role
    - the current task context and phase
@@ -390,26 +416,26 @@ Typical decision flow:
    - how to refresh its own pane record and append a structured handoff in
      `tmux-orch` when available
    - how to continue in tmux-only degraded mode when durable state is unavailable
-7. When `coder`, `issue-gate`, or `reviewer` hands back a result:
+8. When `coder`, `issue-gate`, or `reviewer` hands back a result:
    - record the handoff
    - update `status`, `phase`, and `next_action`
    - decide the next local dispatch
-8. If `next_action=run-issue-gate` and no active `issue-gate` pane exists yet:
+9. If `next_action=run-issue-gate` and no active `issue-gate` pane exists yet:
    - dispatch `$tmux-task-lane-bootstrap-skill` to realize the `issue-gate` lane
    - do not escalate to human confirmation before the `issue-gate` lane has
      produced an actual lookup result or issue draft
-9. For commit-stage work:
+10. For commit-stage work:
    - use `$issue-gate-skill` when traceability still needs confirmation
    - use `$git-commit-skill` when the task is approved and ready to commit
    - keep commit success/failure visible in task state
    - return control to `$tmux-task-orchestrator-skill` after commit instead of
      treating commit completion as the end of the flow
-10. When the task reaches merge-back:
+11. When the task reaches merge-back:
    - use `tmux/bin/tmux-task-project-handoff`
    - never guess the upstream target by pane index or active pane
    - let the helper resolve the canonical project orchestrator pane and append
      the matching durable handoff
-11. After merge-back, mark the task complete and retire phase-scoped lanes.
+12. After merge-back, mark the task complete and retire phase-scoped lanes.
 
 ## Standard Manual Flow (Recommended)
 

--- a/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
@@ -60,7 +60,7 @@ Out of scope:
   happened.
 - In Codex TUI flows, do not add `--full-auto` to `codex fork`.
 - For this orchestrator fork, use `gpt-5.4-mini` with
-  `model_reasoning_effort=medium` and `service_tier=fast`.
+  `model_reasoning_effort=xhigh` and `service_tier=fast`.
 - Do not embed the orchestrator startup prompt directly in the `codex fork`
   command; send it only after fork readiness is confirmed.
 - Stop the parent agent after the fork succeeds.
@@ -72,7 +72,7 @@ Out of scope:
 3. Create the worktree if it does not already exist.
 4. Create or verify the tmux task window for that worktree.
 5. Fork the current Codex session into that tmux window using the lightweight
-   orchestrator profile (`gpt-5.4-mini`, `medium`, `fast`).
+   orchestrator profile (`gpt-5.4-mini`, `xhigh`, `fast`).
 6. Verify the pane has entered Codex after the bare fork command.
 7. If `tmux-orch` is available, initialize or refresh durable state.
    If it is unavailable, continue in tmux-only degraded mode rather than

--- a/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
@@ -63,6 +63,9 @@ Out of scope:
   `model_reasoning_effort=xhigh` and `service_tier=fast`.
 - Do not embed the orchestrator startup prompt directly in the `codex fork`
   command; send it only after fork readiness is confirmed.
+- Treat prompt delivery as confirmed only after a visible marker appears in the
+  child pane transcript; do not report `ready-and-prompted` on process start
+  alone.
 - Stop the parent agent after the fork succeeds.
 
 ## Workflow

--- a/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
@@ -63,6 +63,8 @@ Out of scope:
   `model_reasoning_effort=xhigh` and `service_tier=fast`.
 - Do not embed the orchestrator startup prompt directly in the `codex fork`
   command; send it only after fork readiness is confirmed.
+- Submit the orchestrator startup prompt with literal paste, then two `Enter`
+  keystrokes, then confirm delivery from the child pane transcript.
 - Treat prompt delivery as confirmed only after a visible marker appears in the
   child pane transcript; do not report `ready-and-prompted` on process start
   alone.

--- a/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
@@ -59,6 +59,8 @@ Out of scope:
 - Do not report success until the tmux task window exists and fork dispatch has
   happened.
 - In Codex TUI flows, do not add `--full-auto` to `codex fork`.
+- For this orchestrator fork, use `gpt-5.4-mini` with
+  `model_reasoning_effort=medium` and `service_tier=fast`.
 - Do not embed the orchestrator startup prompt directly in the `codex fork`
   command; send it only after fork readiness is confirmed.
 - Stop the parent agent after the fork succeeds.
@@ -69,7 +71,8 @@ Out of scope:
 2. Resolve `base_branch`, `branch`, `worktree_root`, and `worktree_path`.
 3. Create the worktree if it does not already exist.
 4. Create or verify the tmux task window for that worktree.
-5. Fork the current Codex session into that tmux window.
+5. Fork the current Codex session into that tmux window using the lightweight
+   orchestrator profile (`gpt-5.4-mini`, `medium`, `fast`).
 6. Verify the pane has entered Codex after the bare fork command.
 7. If `tmux-orch` is available, initialize or refresh durable state.
    If it is unavailable, continue in tmux-only degraded mode rather than

--- a/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
@@ -76,7 +76,7 @@ Out of scope:
    blocking task ownership.
 8. Send the orchestrator startup prompt.
    The startup prompt must explicitly tell the new window to continue as
-   `$tmux-task-orchestrator-skill`.
+   `$tmux-task-orchestrator-skill`, not as the fast dispatch role.
 9. Verify:
    - `window_exists=yes`
    - `window_name` is known

--- a/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmux-task-window-bootstrap-skill
-description: v0.1.2 - Internal helper that creates a dedicated task worktree and tmux task window, forks the current session into it, and stops only after task-level ownership is ready.
+description: v0.1.3 - Internal helper that creates a dedicated task worktree and tmux task window, forks the current session into it, sends the orchestrator startup prompt after readiness is confirmed, and stops only after task-level ownership is ready.
 ---
 
 # Tmux Task Window Bootstrap Skill
@@ -59,6 +59,8 @@ Out of scope:
 - Do not report success until the tmux task window exists and fork dispatch has
   happened.
 - In Codex TUI flows, do not add `--full-auto` to `codex fork`.
+- Do not embed the orchestrator startup prompt directly in the `codex fork`
+  command; send it only after fork readiness is confirmed.
 - Stop the parent agent after the fork succeeds.
 
 ## Workflow
@@ -68,15 +70,17 @@ Out of scope:
 3. Create the worktree if it does not already exist.
 4. Create or verify the tmux task window for that worktree.
 5. Fork the current Codex session into that tmux window.
-   The injected child prompt must explicitly tell the new window to continue as
+6. Verify the pane has entered Codex after the bare fork command.
+7. Send the orchestrator startup prompt.
+   The startup prompt must explicitly tell the new window to continue as
    `$tmux-task-orchestrator-skill`.
-6. Verify:
+8. Verify:
    - `window_exists=yes`
    - `window_name` is known
    - `window_id` is known or resolvable
-   - `fork_status=dispatched`
+   - `fork_status=ready-and-prompted`
    - `handoff_ready=yes`
-7. Stop after task-local ownership is ready.
+9. Stop after task-local ownership is ready.
 
 ## References
 

--- a/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
@@ -71,16 +71,19 @@ Out of scope:
 4. Create or verify the tmux task window for that worktree.
 5. Fork the current Codex session into that tmux window.
 6. Verify the pane has entered Codex after the bare fork command.
-7. Send the orchestrator startup prompt.
+7. If `tmux-orch` is available, initialize or refresh durable state.
+   If it is unavailable, continue in tmux-only degraded mode rather than
+   blocking task ownership.
+8. Send the orchestrator startup prompt.
    The startup prompt must explicitly tell the new window to continue as
    `$tmux-task-orchestrator-skill`.
-8. Verify:
+9. Verify:
    - `window_exists=yes`
    - `window_name` is known
    - `window_id` is known or resolvable
    - `fork_status=ready-and-prompted`
    - `handoff_ready=yes`
-9. Stop after task-local ownership is ready.
+10. Stop after task-local ownership is ready.
 
 ## References
 

--- a/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
@@ -26,8 +26,11 @@ tmux/bin/tmux-task-window-bootstrap --repo-root /repo --task-context "..."
 - keep one task per worktree and one task per task window
 - in Codex TUI mode, do not add `--full-auto` to `codex fork`; it forces the
   forked session into `workspace-write` and `on-request`
+- do not embed the orchestrator startup prompt directly in the `codex fork`
+  command; send it only after fork readiness is confirmed
 - do not report downstream handoff as complete until the tmux task window
-  exists and the fork command has actually been injected into it
+  exists, the fork command has been injected, and the startup prompt has been
+  sent after readiness is confirmed
 - stop the parent agent after the fork succeeds
 
 ## Manual Flow
@@ -49,14 +52,20 @@ state_root="${TMUX_ORCH_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/tmux-orch/${
 git -C "$repo_root" worktree add -b "$branch" "$worktree_path" "$base_branch"
 tmux new-window -d -t "$session_name" -n "$window_name" -c "$worktree_path"
 prompt='Continue in this new worktree as $tmux-task-orchestrator-skill for this task. Do not start implementation directly. First confirm repo state and task context, register or refresh the task window in tmux-orch, decide the local phase and next action, and only then dispatch coder, reviewer, or issue work if needed. When lane setup is needed, use $tmux-task-lane-bootstrap-skill rather than creating panes ad hoc.'
-printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q %q --cd %q --no-alt-screen' \
-  "$state_root" "$session_id" "$prompt" "$worktree_path"
+printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen' \
+  "$state_root" "$session_id" "$worktree_path"
 tmux send-keys -t "${session_name}:${window_name}" "$fork_cmd" C-m
+for _ in $(seq 1 40); do
+  [ "$(tmux display-message -p -t "${session_name}:${window_name}" '#{pane_current_command}')" = "codex" ] && break
+  sleep 0.25
+done
+tmux send-keys -t "${session_name}:${window_name}" -l "$prompt"
+tmux send-keys -t "${session_name}:${window_name}" Enter
 ```
 
 ## Prompt Contract
 
-The bootstrap prompt injected into the new task window should always include:
+The bootstrap prompt sent after fork readiness should always include:
 
 - the fact that the child session is now acting as `$tmux-task-orchestrator-skill`
 - the task context and current repo/worktree target
@@ -90,7 +99,7 @@ true:
 - `window_exists=yes`
 - `window_name` is known
 - `window_id` is known or can be resolved immediately
-- `fork_status=dispatched`
+- `fork_status=ready-and-prompted`
 - `handoff_ready=yes`
 
 If the worktree exists but the tmux task window does not, bootstrap is still

--- a/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
@@ -30,6 +30,8 @@ tmux/bin/tmux-task-window-bootstrap --repo-root /repo --task-context "..."
   and `service_tier=fast`
 - do not embed the orchestrator startup prompt directly in the `codex fork`
   command; send it only after fork readiness is confirmed
+- after sending the orchestrator prompt, confirm delivery by checking for a
+  short marker in the pane transcript before reporting `ready-and-prompted`
 - do not report downstream handoff as complete until the tmux task window
   exists, the fork command has been injected, and the startup prompt has been
   sent after readiness is confirmed

--- a/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
@@ -26,6 +26,8 @@ tmux/bin/tmux-task-window-bootstrap --repo-root /repo --task-context "..."
 - keep one task per worktree and one task per task window
 - in Codex TUI mode, do not add `--full-auto` to `codex fork`; it forces the
   forked session into `workspace-write` and `on-request`
+- for the orchestrator fork, use `gpt-5.4-mini` with `model_reasoning_effort=medium`
+  and `service_tier=fast`
 - do not embed the orchestrator startup prompt directly in the `codex fork`
   command; send it only after fork readiness is confirmed
 - do not report downstream handoff as complete until the tmux task window
@@ -52,7 +54,7 @@ state_root="${TMUX_ORCH_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/tmux-orch/${
 git -C "$repo_root" worktree add -b "$branch" "$worktree_path" "$base_branch"
 tmux new-window -d -t "$session_name" -n "$window_name" -c "$worktree_path"
 prompt='Continue in this new worktree as $tmux-task-orchestrator-skill for this task. Do not start implementation directly. First confirm repo state and task context, register or refresh the task window in tmux-orch, decide the local phase and next action, and only then dispatch coder, reviewer, or issue work if needed. When lane setup is needed, use $tmux-task-lane-bootstrap-skill rather than creating panes ad hoc.'
-printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen' \
+printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=medium -c service_tier=fast' \
   "$state_root" "$session_id" "$worktree_path"
 tmux send-keys -t "${session_name}:${window_name}" "$fork_cmd" C-m
 for _ in $(seq 1 40); do

--- a/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
@@ -26,7 +26,7 @@ tmux/bin/tmux-task-window-bootstrap --repo-root /repo --task-context "..."
 - keep one task per worktree and one task per task window
 - in Codex TUI mode, do not add `--full-auto` to `codex fork`; it forces the
   forked session into `workspace-write` and `on-request`
-- for the orchestrator fork, use `gpt-5.4-mini` with `model_reasoning_effort=medium`
+- for the orchestrator fork, use `gpt-5.4-mini` with `model_reasoning_effort=xhigh`
   and `service_tier=fast`
 - do not embed the orchestrator startup prompt directly in the `codex fork`
   command; send it only after fork readiness is confirmed
@@ -54,7 +54,7 @@ state_root="${TMUX_ORCH_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/tmux-orch/${
 git -C "$repo_root" worktree add -b "$branch" "$worktree_path" "$base_branch"
 tmux new-window -d -t "$session_name" -n "$window_name" -c "$worktree_path"
 prompt='Continue in this new worktree as $tmux-task-orchestrator-skill for this task. Do not start implementation directly. First confirm repo state and task context, register or refresh the task window in tmux-orch, decide the local phase and next action, and only then dispatch coder, reviewer, or issue work if needed. When lane setup is needed, use $tmux-task-lane-bootstrap-skill rather than creating panes ad hoc.'
-printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=medium -c service_tier=fast' \
+printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=xhigh -c service_tier=fast' \
   "$state_root" "$session_id" "$worktree_path"
 tmux send-keys -t "${session_name}:${window_name}" "$fork_cmd" C-m
 for _ in $(seq 1 40); do

--- a/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
@@ -30,8 +30,9 @@ tmux/bin/tmux-task-window-bootstrap --repo-root /repo --task-context "..."
   and `service_tier=fast`
 - do not embed the orchestrator startup prompt directly in the `codex fork`
   command; send it only after fork readiness is confirmed
-- after sending the orchestrator prompt, confirm delivery by checking for a
-  short marker in the pane transcript before reporting `ready-and-prompted`
+- after sending the orchestrator prompt with two `Enter` keystrokes, confirm
+  delivery by checking for a short marker in the pane transcript before
+  reporting `ready-and-prompted`
 - do not report downstream handoff as complete until the tmux task window
   exists, the fork command has been injected, and the startup prompt has been
   sent after readiness is confirmed
@@ -64,6 +65,8 @@ for _ in $(seq 1 40); do
   sleep 0.25
 done
 tmux send-keys -t "${session_name}:${window_name}" -l "$prompt"
+tmux send-keys -t "${session_name}:${window_name}" Enter
+sleep 0.2
 tmux send-keys -t "${session_name}:${window_name}" Enter
 ```
 


### PR DESCRIPTION
## Summary
- split tmux lane dispatch from full lifecycle orchestration so fast task-local dispatch no longer has to enter the full project/task control flow
- add degraded dispatch behavior and stronger readiness checks for Codex forks, prompt injection, and startup handoff delivery
- align tmux skills and wrappers with role-specific model profiles and the updated prompt submission contract

## Why
- the original tmux orchestration flow was too heavy for the common case of "start one coder lane now"
- Codex fork readiness and startup prompt delivery were flaky in TUI flows, especially around degraded state roots and prompt submission timing
- unsupported runtime settings such as `service_tier=flex` were causing avoidable startup failures

## Impact
- task windows can dispatch lanes faster without coupling dispatch to review/commit lifecycle management
- bootstrap and lane startup should be more reliable in degraded tmux-orch environments and when Codex needs an extra submit keystroke to accept the startup prompt
- role defaults are now clearer: lightweight orchestrators and high-effort coder/reviewer lanes

## Validation
- `bash -n tmux/bin/tmux-orch-preflight`
- `bash -n tmux/bin/tmux-dispatch-lane`
- `bash -n tmux/bin/tmux-task-lane-bootstrap`
- `bash -n tmux/bin/tmux-task-window-bootstrap`

## Refs
- ISSUE: #31
