### PR TITLE
Refine tmux orchestration flow on company_computer

### DIFF
--- a/tmux/README.md
+++ b/tmux/README.md
@@ -52,6 +52,9 @@
   - 负责 task window 完成后的确定性 upward handoff
   - 只按 canonical `pane_id` 把 `merge-ready` / `merge-complete` / `blocked` /
     `needs-policy` 交回项目级 orchestrator
+- `tmux/bin/tmux-shared-status`
+  - 负责把短状态写到 tmux 第二行共享状态栏
+  - 用于“prompt 已发送”“lane 已派发”这类提示，避免回显完整 prompt 正文
 
 这三条 wrapper 是给编排流程用的。
 现有 `<prefix> + f` / `<prefix> + F` 仍然保持通用裸 `codex fork <id>`，不自动注入 orchestrator 语义。

--- a/tmux/README.md
+++ b/tmux/README.md
@@ -42,10 +42,11 @@
   - 只做 preflight 通过后的 lane 启动，不承担 review/commit/merge 生命周期决策
 - `tmux/bin/tmux-task-window-bootstrap`
   - 负责新 task 的 worktree + tmux window + `tmux-orch` 初始注册（可用时）
-  - 先执行裸 `codex fork`，确认子 pane 进入 Codex 后再发送 orchestrator startup prompt
+  - 只负责创建 task window 并分发裸 `codex fork`
+  - prompt 由调用方显式执行：`tmux send-keys -t <target> -l "$prompt"` -> `Enter` -> `sleep 0.2` -> `Enter`
 - `tmux/bin/tmux-task-lane-bootstrap`
-  - 负责单个 lane pane 的创建、pane 注册、role prompt 注入
-  - 先执行裸 `codex fork`，确认子 pane 进入 Codex 后再发送 lane startup prompt
+  - 负责单个 lane pane 的创建、pane 注册、裸 `codex fork`
+  - prompt 由调用方显式执行：`tmux send-keys -t <target> -l "$prompt"` -> `Enter` -> `sleep 0.2` -> `Enter`
   - 没有 `jq` 或 `tmux/bin/orch` 时，继续以 tmux-only degraded mode 工作，不阻塞 lane 创建
 - `tmux/bin/tmux-task-project-handoff`
   - 负责 task window 完成后的确定性 upward handoff

--- a/tmux/README.md
+++ b/tmux/README.md
@@ -43,10 +43,10 @@
 - `tmux/bin/tmux-task-window-bootstrap`
   - 负责新 task 的 worktree + tmux window + `tmux-orch` 初始注册（可用时）
   - 只负责创建 task window 并分发裸 `codex fork`
-  - prompt 由调用方显式执行：`tmux send-keys -t <target> -l "$prompt"` -> `Enter` -> `sleep 0.2` -> `Enter`
+  - prompt 由调用方显式执行：`tmux send-keys -t <target> -l "$prompt"` -> `Enter` -> `sleep 0.5` -> `Enter`
 - `tmux/bin/tmux-task-lane-bootstrap`
   - 负责单个 lane pane 的创建、pane 注册、裸 `codex fork`
-  - prompt 由调用方显式执行：`tmux send-keys -t <target> -l "$prompt"` -> `Enter` -> `sleep 0.2` -> `Enter`
+  - prompt 由调用方显式执行：`tmux send-keys -t <target> -l "$prompt"` -> `Enter` -> `sleep 0.5` -> `Enter`
   - 没有 `jq` 或 `tmux/bin/orch` 时，继续以 tmux-only degraded mode 工作，不阻塞 lane 创建
 - `tmux/bin/tmux-task-project-handoff`
   - 负责 task window 完成后的确定性 upward handoff

--- a/tmux/bin/tmux-dispatch-lane
+++ b/tmux/bin/tmux-dispatch-lane
@@ -26,6 +26,8 @@ Roles:
 Notes:
   - Public fast path for lane dispatch.
   - Runs tmux-orch-preflight first, then delegates pane mechanics to tmux-task-lane-bootstrap.
+  - Stops after the lane pane exists and bare `codex fork` has been dispatched.
+  - Prompt injection is not handled here; the caller must send it explicitly with `tmux send-keys`.
   - Does not run lifecycle orchestration, review, commit, or merge decisions.
 EOF
 }

--- a/tmux/bin/tmux-shared-status
+++ b/tmux/bin/tmux-shared-status
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  tmux-shared-status --message TEXT
+
+Notes:
+  - Writes a short message to tmux's shared second-line status slot.
+  - Intended for dispatch/handoff confirmations that should not echo full prompt bodies.
+EOF
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+message=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --message)
+      message="$2"
+      shift 2
+      ;;
+    -h|--help|help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "${TMUX:-}" ] || fail "tmux-shared-status must run inside tmux"
+[ -n "$message" ] || fail "--message is required"
+command -v tmux >/dev/null 2>&1 || fail "missing required command: tmux"
+
+message="${message//#/##}"
+tmux set -gq @shared_status_msg "$message"
+tmux refresh-client -S 2>/dev/null || true

--- a/tmux/bin/tmux-task-lane-bootstrap
+++ b/tmux/bin/tmux-task-lane-bootstrap
@@ -25,7 +25,8 @@ Roles:
 
 Notes:
   - Requires tmux and a current Codex session id.
-  - Creates one non-orchestrator lane pane, runs bare `codex fork`, then sends a role-specific prompt after readiness is confirmed.
+  - Creates one non-orchestrator lane pane and dispatches bare `codex fork`.
+  - Prompt injection is not handled here; the caller must send it manually with `tmux send-keys`.
   - Registers the pane in tmux-orch when jq and tmux-orch are available; otherwise continues in tmux-only fallback mode.
 EOF
 }
@@ -76,199 +77,11 @@ default_layout_for_role() {
   esac
 }
 
-pane_ready_for_prompt() {
-  local pane_id="$1"
-  local current_command=""
-  current_command="$(tmux display-message -p -t "$pane_id" '#{pane_current_command}' 2>/dev/null || true)"
-  [ -n "$current_command" ] || return 1
-  [ "$current_command" = "codex" ]
-}
-
-pane_looks_like_codex() {
-  local pane_id="$1"
-  local snapshot=""
-  snapshot="$(tmux capture-pane -p -t "$pane_id" -S -80 2>/dev/null || true)"
-  printf '%s' "$snapshot" | rg -q "OpenAI Codex|Model:|Permissions:|Context window:"
-}
-
 state_root_is_writable() {
   local root="$1"
   local parent
   parent="$(first_existing_dir "$root")"
   [ -w "$parent" ]
-}
-
-wait_for_codex_ready() {
-  local pane_id="$1"
-  local max_attempts="${2:-80}"
-  local attempt=0
-  while [ "$attempt" -lt "$max_attempts" ]; do
-    if pane_ready_for_prompt "$pane_id" || pane_looks_like_codex "$pane_id"; then
-      return 0
-    fi
-    sleep 0.25
-    attempt=$((attempt + 1))
-  done
-  return 1
-}
-
-send_startup_prompt() {
-  local pane_id="$1"
-  local message="$2"
-  tmux send-keys -t "$pane_id" -l "$message"
-  tmux send-keys -t "$pane_id" Enter
-  sleep 0.2
-  tmux send-keys -t "$pane_id" Enter
-}
-
-pane_contains_marker() {
-  local pane_id="$1"
-  local marker="$2"
-  local snapshot=""
-  snapshot="$(tmux capture-pane -p -t "$pane_id" -S -200 2>/dev/null || true)"
-  printf '%s' "$snapshot" | rg -F -q -- "$marker"
-}
-
-wait_for_prompt_marker() {
-  local pane_id="$1"
-  local marker="$2"
-  local max_attempts="${3:-20}"
-  local attempt=0
-  while [ "$attempt" -lt "$max_attempts" ]; do
-    if pane_contains_marker "$pane_id" "$marker"; then
-      return 0
-    fi
-    sleep 0.25
-    attempt=$((attempt + 1))
-  done
-  return 1
-}
-
-send_startup_prompt_confirmed() {
-  local pane_id="$1"
-  local marker="$2"
-  local message="$3"
-  local attempt=0
-  while [ "$attempt" -lt 2 ]; do
-    send_startup_prompt "$pane_id" "$message"
-    if wait_for_prompt_marker "$pane_id" "$marker"; then
-      return 0
-    fi
-    sleep 1
-    attempt=$((attempt + 1))
-  done
-  return 1
-}
-
-build_lane_prompt() {
-  local role="$1"
-  local task_context="$2"
-  local phase="$3"
-  local dispatcher_skill="$4"
-  local fork_profile="$5"
-  local window_id="$6"
-  local pane_id="$7"
-  local orchestrator_pane_id="$8"
-  local state_root="$9"
-  local orch_status="${10}"
-
-  case "$role" in
-    coder)
-      cat <<EOF
-[tmux-lane-bootstrap coder]
-You are the coder lane for this task window.
-This lane was dispatched by $dispatcher_skill.
-Task context: $task_context
-Phase: $phase
-Fork profile: $fork_profile
-Window id: $window_id
-Your pane id: $pane_id
-Orchestrator pane id: $orchestrator_pane_id
-State root: $state_root
-tmux-orch durable state: $orch_status
-Do not redefine scope. Implement only the assigned slice, run the smallest relevant checks, then send a structured handoff back to the orchestrator pane.
-If tmux-orch is available, append the same handoff there. If it is unavailable, continue in tmux-only degraded mode and report that state in your handoff.
-
-Required handoff message envelope:
-[handoff][coder->orchestrator]
-status: <review-ready|blocked|needs-clarification>
-changed_files: <list>
-checks_run: <list>
-risks: <list>
-request: <next action request>
-
-If tmux-orch is available and your runtime status changes, refresh your pane record:
-tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$pane_id" --role coder --scope phase --phase "$phase" --status <active|blocked|idle> --forked-from-session-id "${CODEX_SESSION_ID:-${CODEX_THREAD_ID:-}}"
-
-If tmux-orch is available, append the matching durable handoff:
-tmux/bin/orch handoff --root "$state_root" --window-id "$window_id" --phase "$phase" --from-pane-id "$pane_id" --to-pane-id "$orchestrator_pane_id" --from-role coder --to-role orchestrator --type <status> --payload-json '{"changed_files":[],"checks_run":[],"risks":[],"request":""}'
-EOF
-      ;;
-    issue-gate)
-      cat <<EOF
-[tmux-lane-bootstrap issue-gate]
-You are the issue-gate lane for this task window.
-This lane was dispatched by $dispatcher_skill.
-Task context: $task_context
-Phase: $phase
-Fork profile: $fork_profile
-Window id: $window_id
-Your pane id: $pane_id
-Orchestrator pane id: $orchestrator_pane_id
-State root: $state_root
-tmux-orch durable state: $orch_status
-Confirm issue traceability, draft or refine the issue when needed, and return a structured handoff with the issue outcome, refs line, and whether human confirmation is still needed.
-If tmux-orch is unavailable, continue in tmux-only degraded mode and report that state in your handoff.
-
-Required handoff message envelope:
-[handoff][issue-gate->orchestrator]
-status: <issue-ready|needs-confirmation|blocked>
-issue_ref: <issue or n/a>
-refs_line: <ISSUE: #... or n/a>
-risks: <list>
-request: <next action request>
-
-If tmux-orch is available and your runtime status changes, refresh your pane record:
-tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$pane_id" --role issue-gate --scope phase --phase "$phase" --status <active|blocked|idle> --forked-from-session-id "${CODEX_SESSION_ID:-${CODEX_THREAD_ID:-}}"
-
-If tmux-orch is available, append the matching durable handoff:
-tmux/bin/orch handoff --root "$state_root" --window-id "$window_id" --phase "$phase" --from-pane-id "$pane_id" --to-pane-id "$orchestrator_pane_id" --from-role issue-gate --to-role orchestrator --type <status> --payload-json '{"issue_ref":"","refs_line":"","risks":[],"request":""}'
-EOF
-      ;;
-    reviewer)
-      cat <<EOF
-[tmux-lane-bootstrap reviewer]
-You are the reviewer lane for this task window.
-This lane was dispatched by $dispatcher_skill.
-Task context: $task_context
-Phase: $phase
-Window id: $window_id
-Your pane id: $pane_id
-Orchestrator pane id: $orchestrator_pane_id
-State root: $state_root
-tmux-orch durable state: $orch_status
-Review findings first. Do not edit implementation unless explicitly reassigned. Return one of approved, fix-now, or follow-up with concrete findings.
-If tmux-orch is unavailable, continue in tmux-only degraded mode and report that state in your handoff.
-
-Required handoff message envelope:
-[handoff][reviewer->orchestrator]
-status: <approved|fix-now|follow-up>
-findings: <list>
-checks_run: <list>
-risks: <list>
-request: <next action request>
-
-If tmux-orch is available and your runtime status changes, refresh your pane record:
-tmux/bin/orch register-pane --root "$state_root" --window-id "$window_id" --pane-id "$pane_id" --role reviewer --scope phase --phase "$phase" --status <active|blocked|idle> --forked-from-session-id "${CODEX_SESSION_ID:-${CODEX_THREAD_ID:-}}"
-
-If tmux-orch is available, append the matching durable handoff:
-tmux/bin/orch handoff --root "$state_root" --window-id "$window_id" --phase "$phase" --from-pane-id "$pane_id" --to-pane-id "$orchestrator_pane_id" --from-role reviewer --to-role orchestrator --type <status> --payload-json '{"findings":[],"checks_run":[],"risks":[],"request":""}'
-EOF
-      ;;
-    *)
-      fail "unsupported role: $role"
-      ;;
-  esac
 }
 
 role=""
@@ -347,9 +160,9 @@ done
 [ -n "${TMUX:-}" ] || fail "tmux-task-lane-bootstrap must run inside tmux"
 [ -n "$role" ] || fail "--role is required"
 [ -n "$task_context" ] || fail "--task-context is required"
-[ -n "$target_pane" ] || fail "could not resolve target pane"
 [ -n "$orchestrator_pane_id" ] || fail "could not resolve orchestrator pane id"
 [ -n "$session_id" ] || fail "missing CODEX_SESSION_ID/CODEX_THREAD_ID; pass --session-id explicitly"
+[ -n "$target_pane" ] || fail "could not resolve target pane"
 
 need_cmd tmux
 
@@ -396,39 +209,17 @@ if [ "$orch_enabled" = "yes" ]; then
     --forked-from-pane-id "$orchestrator_pane_id" >/dev/null
 fi
 
-fork_profile="gpt-5.4-mini / xhigh / fast"
 fork_cmd="TMUX_ORCH_ROOT=$(printf '%q' "$state_root") codex fork $(printf '%q' "$session_id") --cd $(printf '%q' "$worktree_path") --no-alt-screen"
 case "$role" in
   coder | reviewer)
-    fork_profile="gpt-5.4 / xhigh"
     fork_cmd="$fork_cmd -m gpt-5.4 -c model_reasoning_effort=xhigh"
     ;;
   issue-gate)
-    fork_profile="gpt-5.4-mini / xhigh / fast"
     fork_cmd="$fork_cmd -m gpt-5.4-mini -c model_reasoning_effort=xhigh -c service_tier=fast"
     ;;
 esac
-prompt="$(build_lane_prompt "$role" "$task_context" "$phase" "$dispatcher_skill" "$fork_profile" "$window_id" "$new_pane_id" "$orchestrator_pane_id" "$state_root" "$orch_status")"
-prompt_marker="[tmux-lane-bootstrap $role]"
 tmux send-keys -t "$new_pane_id" "$fork_cmd" C-m
 fork_status="fork-dispatched"
-if wait_for_codex_ready "$new_pane_id"; then
-  if send_startup_prompt_confirmed "$new_pane_id" "$prompt_marker" "$prompt"; then
-    fork_status="ready-and-prompted"
-  else
-    fork_status="ready-prompt-unconfirmed"
-  fi
-else
-  if pane_ready_for_prompt "$new_pane_id" || pane_looks_like_codex "$new_pane_id"; then
-    if send_startup_prompt_confirmed "$new_pane_id" "$prompt_marker" "$prompt"; then
-      fork_status="ready-after-timeout"
-    else
-      fork_status="ready-after-timeout-unconfirmed"
-    fi
-  else
-    fork_status="fork-timeout"
-  fi
-fi
 
 printf '## Lane Bootstrap\n'
 printf -- '- role: %s\n' "$role"

--- a/tmux/bin/tmux-task-project-handoff
+++ b/tmux/bin/tmux-task-project-handoff
@@ -71,7 +71,7 @@ send_multiline_message() {
   local message="$2"
   tmux send-keys -t "$target" -l "$message"
   tmux send-keys -t "$target" Enter
-  sleep 0.2
+  sleep 0.5
   tmux send-keys -t "$target" Enter
 }
 

--- a/tmux/bin/tmux-task-window-bootstrap
+++ b/tmux/bin/tmux-task-window-bootstrap
@@ -24,7 +24,8 @@ Notes:
   - Requires tmux, git, and a current Codex session id.
   - Uses $TMUX_ORCH_ROOT or the default tmux-orch session root when --root is omitted.
   - Uses tmux-only fallback mode when jq or tmux-orch is unavailable.
-  - Uses a two-step startup: bare `codex fork`, then a startup prompt after the pane is ready.
+  - Uses a two-step startup: create the task window, then dispatch bare `codex fork`.
+  - Prompt injection is not handled here; the caller must send it manually with `tmux send-keys`.
 EOF
 }
 
@@ -70,19 +71,15 @@ slugify() {
   printf '%.48s' "$value"
 }
 
-pane_ready_for_prompt() {
-  local pane_id="$1"
-  local current_command=""
-  current_command="$(tmux display-message -p -t "$pane_id" '#{pane_current_command}' 2>/dev/null || true)"
-  [ -n "$current_command" ] || return 1
-  [ "$current_command" = "codex" ]
-}
-
-pane_looks_like_codex() {
-  local pane_id="$1"
-  local snapshot=""
-  snapshot="$(tmux capture-pane -p -t "$pane_id" -S -80 2>/dev/null || true)"
-  printf '%s' "$snapshot" | rg -q "OpenAI Codex|Model:|Permissions:|Context window:"
+shell_like_command() {
+  case "$1" in
+    "" | bash | sh | zsh | fish | nu)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 state_root_is_writable() {
@@ -90,68 +87,6 @@ state_root_is_writable() {
   local parent
   parent="$(first_existing_dir "$root")"
   [ -w "$parent" ]
-}
-
-wait_for_codex_ready() {
-  local pane_id="$1"
-  local max_attempts="${2:-80}"
-  local attempt=0
-  while [ "$attempt" -lt "$max_attempts" ]; do
-    if pane_ready_for_prompt "$pane_id" || pane_looks_like_codex "$pane_id"; then
-      return 0
-    fi
-    sleep 0.25
-    attempt=$((attempt + 1))
-  done
-  return 1
-}
-
-send_startup_prompt() {
-  local pane_id="$1"
-  local message="$2"
-  tmux send-keys -t "$pane_id" -l "$message"
-  tmux send-keys -t "$pane_id" Enter
-  sleep 0.2
-  tmux send-keys -t "$pane_id" Enter
-}
-
-pane_contains_marker() {
-  local pane_id="$1"
-  local marker="$2"
-  local snapshot=""
-  snapshot="$(tmux capture-pane -p -t "$pane_id" -S -200 2>/dev/null || true)"
-  printf '%s' "$snapshot" | rg -F -q -- "$marker"
-}
-
-wait_for_prompt_marker() {
-  local pane_id="$1"
-  local marker="$2"
-  local max_attempts="${3:-20}"
-  local attempt=0
-  while [ "$attempt" -lt "$max_attempts" ]; do
-    if pane_contains_marker "$pane_id" "$marker"; then
-      return 0
-    fi
-    sleep 0.25
-    attempt=$((attempt + 1))
-  done
-  return 1
-}
-
-send_startup_prompt_confirmed() {
-  local pane_id="$1"
-  local marker="$2"
-  local message="$3"
-  local attempt=0
-  while [ "$attempt" -lt 2 ]; do
-    send_startup_prompt "$pane_id" "$message"
-    if wait_for_prompt_marker "$pane_id" "$marker"; then
-      return 0
-    fi
-    sleep 1
-    attempt=$((attempt + 1))
-  done
-  return 1
 }
 
 repo_root=""
@@ -320,51 +255,14 @@ if [ "$orch_enabled" = "yes" ]; then
     --status active >/dev/null
 fi
 
-prompt="$(cat <<EOF
-[tmux-window-bootstrap orchestrator]
-Continue in this new worktree as \$tmux-task-orchestrator-skill for this task.
-Task context: $task_context
-Repo root: $repo_root
-Worktree path: $worktree_path
-Branch: $branch
-State root: $state_root
-Do not start implementation directly.
-tmux-orch durable state: $orch_status
-Fork profile: gpt-5.4-mini / xhigh / fast
-First confirm repo state and task context, register or refresh the task window in tmux-orch if it is available, decide the local phase and next action, and only then dispatch coder, reviewer, or issue work if needed.
-If tmux-orch is unavailable in this environment, continue in tmux-only degraded mode rather than blocking lane setup.
-When lane setup is needed, use \$tmux-task-lane-bootstrap-skill rather than creating panes ad hoc.
-EOF
-)"
-prompt_marker="[tmux-window-bootstrap orchestrator]"
-
 if [ "$fork_status" != "existing-window-busy" ]; then
   printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=xhigh -c service_tier=fast' \
     "$state_root" "$session_id" "$worktree_path"
   tmux send-keys -t "$orchestrator_pane_id" "$fork_cmd" C-m
-  if wait_for_codex_ready "$orchestrator_pane_id"; then
-    if send_startup_prompt_confirmed "$orchestrator_pane_id" "$prompt_marker" "$prompt"; then
-      fork_status="ready-and-prompted"
-    else
-      fork_status="ready-prompt-unconfirmed"
-    fi
-  else
-    if pane_ready_for_prompt "$orchestrator_pane_id" || pane_looks_like_codex "$orchestrator_pane_id"; then
-      if send_startup_prompt_confirmed "$orchestrator_pane_id" "$prompt_marker" "$prompt"; then
-        fork_status="ready-after-timeout"
-      else
-        fork_status="ready-after-timeout-unconfirmed"
-      fi
-    else
-      fork_status="fork-timeout"
-    fi
-  fi
+  fork_status="fork-dispatched"
 fi
 
-handoff_ready="yes"
-if [ "$fork_status" = "existing-window-busy" ] || [ "$fork_status" = "fork-timeout" ] || [ "$fork_status" = "ready-prompt-unconfirmed" ] || [ "$fork_status" = "ready-after-timeout-unconfirmed" ]; then
-  handoff_ready="no"
-fi
+handoff_ready="no"
 
 printf '## Bootstrap State\n'
 printf -- '- repo_root: %s\n' "$repo_root"

--- a/tmux/skills/tmux-lane-dispatch-skill/SKILL.md
+++ b/tmux/skills/tmux-lane-dispatch-skill/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when the goal is:
 
 - create one lane quickly
 - keep the current pane as the local control point
-- stop after the lane is ready and prompted
+- stop after the lane pane exists and bare `codex fork` has been dispatched
 
 Do not use this skill when the goal is to manage review, commit, merge-back, or
 task lifecycle state over time. In those cases, use
@@ -31,6 +31,7 @@ In scope:
 - resolve the current tmux pane/window context
 - dispatch one lane through `tmux-dispatch-lane`
 - return the resolved pane map and fork status
+- leave prompt injection to an explicit `tmux send-keys` step
 
 Out of scope:
 
@@ -56,7 +57,7 @@ Out of scope:
 - `entry_mode=dispatch-fast-path`
 - `preflight_mode=dispatch`
 - `lane_role_default=coder`
-- `post_dispatch_policy=stop-after-pane-ready`
+- `post_dispatch_policy=stop-after-fork-dispatched`
 
 ## Workflow
 
@@ -65,7 +66,10 @@ Out of scope:
 3. If required checks fail, stop and report the blockers.
 4. If required checks pass, call `tmux/bin/tmux-dispatch-lane`.
 5. Return the created pane id, fork status, and durable-state mode.
-6. Stop. Do not continue into review, commit, or merge logic.
+6. If the caller wants the lane to start working immediately, inject the prompt
+   explicitly with:
+   `tmux send-keys -t <pane> -l "$prompt"` -> `Enter` -> `sleep 0.2` -> `Enter`
+7. Stop. Do not continue into review, commit, or merge logic.
 
 ## Guardrails
 

--- a/tmux/skills/tmux-lane-dispatch-skill/SKILL.md
+++ b/tmux/skills/tmux-lane-dispatch-skill/SKILL.md
@@ -68,7 +68,7 @@ Out of scope:
 5. Return the created pane id, fork status, and durable-state mode.
 6. If the caller wants the lane to start working immediately, inject the prompt
    explicitly with:
-   `tmux send-keys -t <pane> -l "$prompt"` -> `Enter` -> `sleep 0.2` -> `Enter`
+   `tmux send-keys -t <pane> -l "$prompt"` -> `Enter` -> `sleep 0.5` -> `Enter`
 7. Stop. Do not continue into review, commit, or merge logic.
 
 ## Guardrails

--- a/tmux/skills/tmux-lane-dispatch-skill/SKILL.md
+++ b/tmux/skills/tmux-lane-dispatch-skill/SKILL.md
@@ -69,6 +69,9 @@ Out of scope:
 6. If the caller wants the lane to start working immediately, inject the prompt
    explicitly with:
    `tmux send-keys -t <pane> -l "$prompt"` -> `Enter` -> `sleep 0.5` -> `Enter`
+   Then publish only a short status such as `reviewer prompt sent: %257` via
+   `tmux/bin/tmux-shared-status`; do not echo the full prompt body in user-facing
+   commentary.
 7. Stop. Do not continue into review, commit, or merge logic.
 
 ## Guardrails
@@ -79,6 +82,10 @@ Out of scope:
 - Do not recreate pane mechanics inline; use `tmux/bin/tmux-dispatch-lane`.
 - Treat degraded mode as usable for dispatch only when preflight says
   `can_dispatch_lane=yes`.
+- Do not repeat full prompt bodies in commentary or summaries after sending
+  them to a pane.
+- Do not inline full prompt bodies inside user-visible shell commands such as
+  heredocs, `prompt=...`, or long `printf` command strings.
 
 ## References
 

--- a/tmux/skills/tmux-project-orchestrator-skill/SKILL.md
+++ b/tmux/skills/tmux-project-orchestrator-skill/SKILL.md
@@ -323,6 +323,10 @@ Reference:
   deployment is still Phase A session-scoped only.
 - Do not leave the canonical project orchestrator pane implicit; register it in
   tmux session state and `tmux-orch` before dispatching task windows.
+- Do not repeat full prompt bodies in commentary after sending them to task
+  windows or lanes.
+- Do not inline full prompt bodies inside user-visible shell commands when
+  preparing downstream prompts.
 
 ## Recommended Task Sequence
 
@@ -361,6 +365,8 @@ Reference:
    - use a bare `codex fork` first
    - send the downstream startup prompt explicitly with:
      `tmux send-keys -t <target> -l "$prompt"` -> `Enter` -> `sleep 0.5` -> `Enter`
+   - after sending, use `tmux/bin/tmux-shared-status` for a short confirmation
+     rather than echoing the full prompt body
    - make the downstream startup prompt explicitly require:
      - use `$tmux-task-orchestrator-skill`
      - do not start implementation directly

--- a/tmux/skills/tmux-project-orchestrator-skill/SKILL.md
+++ b/tmux/skills/tmux-project-orchestrator-skill/SKILL.md
@@ -360,7 +360,7 @@ Reference:
    - preserve the current `TMUX_ORCH_ROOT`
    - use a bare `codex fork` first
    - send the downstream startup prompt explicitly with:
-     `tmux send-keys -t <target> -l "$prompt"` -> `Enter` -> `sleep 0.2` -> `Enter`
+     `tmux send-keys -t <target> -l "$prompt"` -> `Enter` -> `sleep 0.5` -> `Enter`
    - make the downstream startup prompt explicitly require:
      - use `$tmux-task-orchestrator-skill`
      - do not start implementation directly

--- a/tmux/skills/tmux-project-orchestrator-skill/SKILL.md
+++ b/tmux/skills/tmux-project-orchestrator-skill/SKILL.md
@@ -358,8 +358,9 @@ Reference:
 6. If a new task window is required:
    - call `$tmux-task-window-bootstrap-skill`
    - preserve the current `TMUX_ORCH_ROOT`
-   - use a bare `codex fork` first, then send the startup prompt only after the
-     child pane is ready
+   - use a bare `codex fork` first
+   - send the downstream startup prompt explicitly with:
+     `tmux send-keys -t <target> -l "$prompt"` -> `Enter` -> `sleep 0.2` -> `Enter`
    - make the downstream startup prompt explicitly require:
      - use `$tmux-task-orchestrator-skill`
      - do not start implementation directly
@@ -372,8 +373,7 @@ Reference:
    - the target tmux window exists
    - `window_name` and `window_id` are known
    - the fork command has been dispatched into that window
-   - the startup prompt has been sent only after the child pane is ready
-   - `handoff_ready=yes` only after those checks pass
+   - `handoff_ready=no` until the caller has explicitly sent the prompt
 8. When a task window becomes the active focus, let
    `$tmux-task-orchestrator-skill` own:
    - task-local phase

--- a/tmux/skills/tmux-project-orchestrator-skill/docs/tmux-orch-state-contract.md
+++ b/tmux/skills/tmux-project-orchestrator-skill/docs/tmux-orch-state-contract.md
@@ -347,7 +347,8 @@ When `tmux-orch` exists, `$tmux-task-lane-bootstrap-skill` should:
 ### Lane Prompt Contract
 
 When a lane pane is created, the startup prompt should give the lane enough
-context to report back without guessing.
+context to report back without guessing. The prompt is sent explicitly by the
+caller with raw `tmux send-keys`; it is not part of lane bootstrap itself.
 
 Minimum prompt fields:
 

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
@@ -72,7 +72,7 @@ Out of scope:
   `model_reasoning_effort=xhigh` and `service_tier=fast`.
 - Do not send the lane startup prompt from this helper.
 - The caller must inject the prompt explicitly with:
-  `tmux send-keys -t <pane> -l "$prompt"` -> `Enter` -> `sleep 0.2` -> `Enter`.
+  `tmux send-keys -t <pane> -l "$prompt"` -> `Enter` -> `sleep 0.5` -> `Enter`.
 - Use tmux `pane_id` as the only machine routing key.
 - Use a dedicated reviewer pane for formal review.
 

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmux-task-lane-bootstrap-skill
-description: v0.1.3 - Internal helper that realizes lane layout, lane startup, pane_id registration, and phase-scoped lane retirement inside one task window after task-level orchestration has already chosen the next local action.
+description: v0.1.3 - Internal helper that realizes lane layout, bare fork dispatch, pane_id registration, and phase-scoped lane retirement inside one task window after task-level orchestration has already chosen the next local action.
 ---
 
 # Tmux Task Lane Bootstrap Skill
@@ -22,7 +22,6 @@ In scope:
 - capture canonical `pane_id` values
 - register panes and pane roles in `tmux-orch` when used
 - fork child lanes from the current orchestrator session
-- send role-first startup prompts
 - retire or recreate phase-scoped panes when task-window policy has authorized it
 
 Out of scope:
@@ -57,7 +56,6 @@ Out of scope:
 
 - `routing_key=pane_id`
 - `phase_scope=non-orchestrator-lanes`
-- `message_mode=literal-double-enter-confirmed`
 - `execution_mode=lane-bootstrap-only`
 - `coder/reviewer fork profile=gpt-5.4/xhigh`
 - `issue-gate fork profile=gpt-5.4-mini/xhigh/fast`
@@ -72,13 +70,9 @@ Out of scope:
   orchestrator profile.
 - For issue-gate lanes, explicitly use `gpt-5.4-mini` with
   `model_reasoning_effort=xhigh` and `service_tier=fast`.
-- Do not embed the lane startup prompt directly in the `codex fork` command;
-  send it only after fork readiness is confirmed.
-- Submit the lane startup prompt with literal paste, then two `Enter`
-  keystrokes, then confirm delivery from the child pane transcript.
-- Treat prompt delivery as confirmed only after a visible marker appears in the
-  child pane transcript; do not report `ready-and-prompted` on process start
-  alone.
+- Do not send the lane startup prompt from this helper.
+- The caller must inject the prompt explicitly with:
+  `tmux send-keys -t <pane> -l "$prompt"` -> `Enter` -> `sleep 0.2` -> `Enter`.
 - Use tmux `pane_id` as the only machine routing key.
 - Use a dedicated reviewer pane for formal review.
 
@@ -91,17 +85,8 @@ Out of scope:
 5. Register panes and fork provenance in `tmux-orch` when used.
 6. Fork child lanes from the current orchestrator session without embedding the
    startup prompt in the `codex fork` command.
-7. Confirm the child pane has entered Codex.
-8. Send role-first prompts with literal paste, two `Enter` keystrokes, and
-   transcript confirmation. The prompt must include:
-   - current role and task context
-   - `window_id`, current `pane_id`, `orchestrator_pane_id`, and `TMUX_ORCH_ROOT`
-   - the required handoff message envelope
-   - how the lane should refresh its own pane status and append a matching
-     handoff in `tmux-orch` when available
-   - how the lane should continue in tmux-only degraded mode when durable state
-     registration is unavailable
-9. Return the resolved pane map to the calling role.
+7. Stop after the fork command has been dispatched.
+8. Return the resolved pane map and fork status to the calling role.
 
 ## References
 

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/SKILL.md
@@ -73,6 +73,10 @@ Out of scope:
 - Do not send the lane startup prompt from this helper.
 - The caller must inject the prompt explicitly with:
   `tmux send-keys -t <pane> -l "$prompt"` -> `Enter` -> `sleep 0.5` -> `Enter`.
+- After prompt injection, prefer a short `tmux/bin/tmux-shared-status`
+  confirmation instead of repeating the full prompt body in commentary.
+- Do not inline full prompt bodies inside user-visible shell commands when
+  preparing lane prompts.
 - Use tmux `pane_id` as the only machine routing key.
 - Use a dedicated reviewer pane for formal review.
 

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
@@ -17,8 +17,6 @@ tmux/bin/tmux-task-lane-bootstrap --role coder --task-context "..." --phase phas
 - create the pane layout for one task window
 - capture canonical `pane_id` values immediately
 - fork non-orchestrator panes from the current orchestrator session
-- send role-first startup prompts after fork readiness is confirmed, using
-  literal paste plus two `Enter` keystrokes before transcript confirmation
 - keep tmux window options and `tmux-orch` pane state aligned
 
 ## Required Rules
@@ -34,10 +32,10 @@ tmux/bin/tmux-task-lane-bootstrap --role coder --task-context "..." --phase phas
   orchestrator profile
 - for issue-gate lanes, explicitly use `gpt-5.4-mini` with
   `model_reasoning_effort=xhigh` and `service_tier=fast`
-- do not embed startup prompts directly in `codex fork`; fork first, verify the
-  child pane is in Codex, then send the prompt with two `Enter` keystrokes
-- after sending the prompt, confirm delivery by checking for a short marker in
-  the pane transcript before reporting `ready-and-prompted`
+- do not embed startup prompts directly in `codex fork`
+- do not send startup prompts from the bootstrap helper
+- inject the prompt explicitly with the raw `tmux send-keys` sequence after the
+  fork command has been dispatched
 - use a dedicated reviewer pane for formal review
 - recreate phase-scoped panes across phase boundaries
 
@@ -73,25 +71,12 @@ printf -v issue_fork 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m
   "$state_root" "$orchestrator_session_id" "$worktree_path"
 tmux send-keys -t "$coder_pane" "$coder_fork" C-m
 tmux send-keys -t "$issue_pane" "$issue_fork" C-m
-for _ in $(seq 1 40); do
-  [ "$(tmux display-message -p -t "$coder_pane" '#{pane_current_command}')" = "codex" ] && break
-  sleep 0.25
-done
-for _ in $(seq 1 40); do
-  [ "$(tmux display-message -p -t "$issue_pane" '#{pane_current_command}')" = "codex" ] && break
-  sleep 0.25
-done
 ```
 
-## Role-First Startup Messages
+## Prompt Injection
 
-Every non-orchestrator pane should begin with:
-
-```text
-You are the <role> lane for this task window.
-```
-
-Suggested send pattern:
+After the pane exists and the bare fork command has been sent, inject the lane
+prompt explicitly:
 
 ```bash
 message="$(printf 'You are the coder lane for this task window.\nThe task plan is already decided by $tmux-task-orchestrator-skill.\nRole: coder\nWindow id: %s\nYour pane id: %s\nOrchestrator pane id: %s\nState root: %s\nBefore returning control, refresh your pane status if needed, send a structured handoff message to the orchestrator pane, and append the same handoff to tmux-orch.\nReport changed files, checks run, risks, and a clear request for the next action.' \"$window_id\" \"$coder_pane\" \"$orch_pane\" \"$state_root\")"

--- a/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
+++ b/tmux/skills/tmux-task-lane-bootstrap-skill/references/pane-lane-bootstrap.md
@@ -82,7 +82,7 @@ prompt explicitly:
 message="$(printf 'You are the coder lane for this task window.\nThe task plan is already decided by $tmux-task-orchestrator-skill.\nRole: coder\nWindow id: %s\nYour pane id: %s\nOrchestrator pane id: %s\nState root: %s\nBefore returning control, refresh your pane status if needed, send a structured handoff message to the orchestrator pane, and append the same handoff to tmux-orch.\nReport changed files, checks run, risks, and a clear request for the next action.' \"$window_id\" \"$coder_pane\" \"$orch_pane\" \"$state_root\")"
 tmux send-keys -t "$coder_pane" -l "$message"
 tmux send-keys -t "$coder_pane" Enter
-sleep 0.2
+sleep 0.5
 tmux send-keys -t "$coder_pane" Enter
 ```
 

--- a/tmux/skills/tmux-task-orchestrator-skill/SKILL.md
+++ b/tmux/skills/tmux-task-orchestrator-skill/SKILL.md
@@ -87,6 +87,10 @@ Requires explicit human or project-level approval when:
 - when lanes are needed, pass a lane prompt contract so each child pane knows
   how to report back, how to refresh its pane status, and how to append a
   matching handoff to `tmux-orch`
+- do not repeat full prompt bodies in commentary or summaries after sending
+  them to panes
+- do not inline full prompt bodies inside user-visible shell commands when
+  preparing prompts
 
 ## Inputs And Outputs
 

--- a/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
@@ -64,6 +64,10 @@ Out of scope:
 - Do not send the orchestrator startup prompt from this helper.
 - The caller must inject the prompt explicitly with:
   `tmux send-keys -t <pane> -l "$prompt"` -> `Enter` -> `sleep 0.5` -> `Enter`.
+- After prompt injection, prefer a short `tmux/bin/tmux-shared-status`
+  confirmation instead of repeating the full prompt body in commentary.
+- Do not inline full prompt bodies inside user-visible shell commands when
+  preparing orchestrator startup prompts.
 - Stop the parent agent after the fork succeeds.
 
 ## Workflow

--- a/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
@@ -63,7 +63,7 @@ Out of scope:
   `model_reasoning_effort=xhigh` and `service_tier=fast`.
 - Do not send the orchestrator startup prompt from this helper.
 - The caller must inject the prompt explicitly with:
-  `tmux send-keys -t <pane> -l "$prompt"` -> `Enter` -> `sleep 0.2` -> `Enter`.
+  `tmux send-keys -t <pane> -l "$prompt"` -> `Enter` -> `sleep 0.5` -> `Enter`.
 - Stop the parent agent after the fork succeeds.
 
 ## Workflow

--- a/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmux-task-window-bootstrap-skill
-description: v0.1.3 - Internal helper that creates a dedicated task worktree and tmux task window, forks the current session into it, sends the orchestrator startup prompt after readiness is confirmed, and stops only after task-level ownership is ready.
+description: v0.1.3 - Internal helper that creates a dedicated task worktree and tmux task window, dispatches a bare orchestrator fork into it, and stops before prompt injection.
 ---
 
 # Tmux Task Window Bootstrap Skill
@@ -18,7 +18,7 @@ In scope:
 - create a dedicated git worktree for one task
 - create or verify the first tmux task window for that worktree
 - fork the current Codex session into that window
-- verify that task-local handoff is actually ready before stopping
+- stop after the bare fork command has been dispatched
 
 Out of scope:
 
@@ -61,13 +61,9 @@ Out of scope:
 - In Codex TUI flows, do not add `--full-auto` to `codex fork`.
 - For this orchestrator fork, use `gpt-5.4-mini` with
   `model_reasoning_effort=xhigh` and `service_tier=fast`.
-- Do not embed the orchestrator startup prompt directly in the `codex fork`
-  command; send it only after fork readiness is confirmed.
-- Submit the orchestrator startup prompt with literal paste, then two `Enter`
-  keystrokes, then confirm delivery from the child pane transcript.
-- Treat prompt delivery as confirmed only after a visible marker appears in the
-  child pane transcript; do not report `ready-and-prompted` on process start
-  alone.
+- Do not send the orchestrator startup prompt from this helper.
+- The caller must inject the prompt explicitly with:
+  `tmux send-keys -t <pane> -l "$prompt"` -> `Enter` -> `sleep 0.2` -> `Enter`.
 - Stop the parent agent after the fork succeeds.
 
 ## Workflow
@@ -78,20 +74,17 @@ Out of scope:
 4. Create or verify the tmux task window for that worktree.
 5. Fork the current Codex session into that tmux window using the lightweight
    orchestrator profile (`gpt-5.4-mini`, `xhigh`, `fast`).
-6. Verify the pane has entered Codex after the bare fork command.
-7. If `tmux-orch` is available, initialize or refresh durable state.
+6. If `tmux-orch` is available, initialize or refresh durable state.
    If it is unavailable, continue in tmux-only degraded mode rather than
    blocking task ownership.
-8. Send the orchestrator startup prompt.
-   The startup prompt must explicitly tell the new window to continue as
-   `$tmux-task-orchestrator-skill`, not as the fast dispatch role.
-9. Verify:
+7. Verify:
    - `window_exists=yes`
    - `window_name` is known
    - `window_id` is known or resolvable
-   - `fork_status=ready-and-prompted`
-   - `handoff_ready=yes`
-10. Stop after task-local ownership is ready.
+   - `fork_status=fork-dispatched`
+   - `handoff_ready=no`
+8. Stop. The caller must send the orchestrator prompt explicitly in a separate
+   step.
 
 ## References
 

--- a/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
@@ -61,7 +61,7 @@ printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m g
 tmux send-keys -t "${session_name}:${window_name}" "$fork_cmd" C-m
 tmux send-keys -t "${session_name}:${window_name}" -l "$prompt"
 tmux send-keys -t "${session_name}:${window_name}" Enter
-sleep 0.2
+sleep 0.5
 tmux send-keys -t "${session_name}:${window_name}" Enter
 ```
 

--- a/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
+++ b/tmux/skills/tmux-task-window-bootstrap-skill/references/worktree-bootstrap.md
@@ -29,13 +29,12 @@ tmux/bin/tmux-task-window-bootstrap --repo-root /repo --task-context "..."
 - for the orchestrator fork, use `gpt-5.4-mini` with `model_reasoning_effort=xhigh`
   and `service_tier=fast`
 - do not embed the orchestrator startup prompt directly in the `codex fork`
-  command; send it only after fork readiness is confirmed
-- after sending the orchestrator prompt with two `Enter` keystrokes, confirm
-  delivery by checking for a short marker in the pane transcript before
-  reporting `ready-and-prompted`
-- do not report downstream handoff as complete until the tmux task window
-  exists, the fork command has been injected, and the startup prompt has been
-  sent after readiness is confirmed
+  command
+- do not send the orchestrator startup prompt from the bootstrap helper
+- inject the prompt explicitly with the raw `tmux send-keys` sequence after the
+  fork command has been dispatched
+- do not report downstream handoff as complete until the caller has sent the
+  orchestrator prompt in a separate step
 - stop the parent agent after the fork succeeds
 
 ## Manual Flow
@@ -60,10 +59,6 @@ prompt='Continue in this new worktree as $tmux-task-orchestrator-skill for this 
 printf -v fork_cmd 'TMUX_ORCH_ROOT=%q codex fork %q --cd %q --no-alt-screen -m gpt-5.4-mini -c model_reasoning_effort=xhigh -c service_tier=fast' \
   "$state_root" "$session_id" "$worktree_path"
 tmux send-keys -t "${session_name}:${window_name}" "$fork_cmd" C-m
-for _ in $(seq 1 40); do
-  [ "$(tmux display-message -p -t "${session_name}:${window_name}" '#{pane_current_command}')" = "codex" ] && break
-  sleep 0.25
-done
 tmux send-keys -t "${session_name}:${window_name}" -l "$prompt"
 tmux send-keys -t "${session_name}:${window_name}" Enter
 sleep 0.2
@@ -72,7 +67,7 @@ tmux send-keys -t "${session_name}:${window_name}" Enter
 
 ## Prompt Contract
 
-The bootstrap prompt sent after fork readiness should always include:
+The bootstrap prompt sent explicitly by the caller should always include:
 
 - the fact that the child session is now acting as `$tmux-task-orchestrator-skill`
 - the task context and current repo/worktree target
@@ -106,8 +101,8 @@ true:
 - `window_exists=yes`
 - `window_name` is known
 - `window_id` is known or can be resolved immediately
-- `fork_status=ready-and-prompted`
-- `handoff_ready=yes`
+- `fork_status=fork-dispatched`
+- `handoff_ready=no`
 
 If the worktree exists but the tmux task window does not, bootstrap is still
 incomplete and the parent role must not claim task-local ownership has already


### PR DESCRIPTION
## Summary
- refine the tmux orchestration flow on `company_computer`
- split dispatch from lifecycle orchestration and harden the tmux wrapper boundaries
- simplify prompt dispatch, lengthen submit timing, and avoid repeating prompt bodies in operator feedback

## Validation
- `bash -n tmux/bin/tmux-task-window-bootstrap`
- `bash -n tmux/bin/tmux-task-lane-bootstrap`
- `bash -n tmux/bin/tmux-dispatch-lane`
- `bash -n tmux/bin/tmux-task-project-handoff`
- `bash -n tmux/bin/tmux-shared-status`
- tmux smoke checks for lane dispatch and explicit prompt injection

## Notes
- base branch: `JeanphiloGong/nvim-config:company_computer`
- head branch: `shio-chan-dev:nvim-config:company_computer`
